### PR TITLE
feat(126631): :sparkles: adiciona permissões aos usuários para alterar vínculos

### DIFF
--- a/sme_sigpae_api/dados_comuns/permissions.py
+++ b/sme_sigpae_api/dados_comuns/permissions.py
@@ -538,6 +538,8 @@ class UsuarioPodeAlterarVinculo(BasePermission):
             and isinstance(usuario.vinculo_atual.instituicao, Codae)
             and usuario.vinculo_atual.perfil.nome
             in [
+                COORDENADOR_GESTAO_PRODUTO,
+                ADMINISTRADOR_GESTAO_PRODUTO,
                 COORDENADOR_CODAE_DILOG_LOGISTICA,
                 COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA,
                 ADMINISTRADOR_REPRESENTANTE_CODAE,


### PR DESCRIPTION
# Este PR

- Adiciona permissões aos perfis COORDENADOR_GESTAO_PRODUTO e ADMINISTRADOR_GESTAO_PRODUTO para alterar vínculos.

### Referência Azure

- 126631