### PR TITLE
Hotfix/corrige template gestao alimentacao

### DIFF
--- a/sme_sigpae_api/relatorios/templates/cabecalho_rodape_solicitacao.html
+++ b/sme_sigpae_api/relatorios/templates/cabecalho_rodape_solicitacao.html
@@ -52,9 +52,11 @@
     <img src="{% static 'images/LOGO_FUNDO_CLARO.png' %}" alt=""/>
     <h1>Sistema de gestão do programa de alimentação escolar</h1>
   </section>
-  <section >
-    <h2 class="subtitulo-centralizado">PROTOCOLO PADRÃO DE DIETA ESPECIAL</h2>
-  </section>
+  {% if eh_protocolo_dieta_especial %}
+    <section >
+      <h2 class="subtitulo-centralizado">PROTOCOLO PADRÃO DE DIETA ESPECIAL</h2>
+    </section>
+  {% endif %}
   <table class="tabela-cabecalho tabela-arredondada">
     <tr class="">
       <td>{{ escola.nome }}</td>


### PR DESCRIPTION
# Este PR:
- corrige erro que exibia titulo de dieta especial nos relatórios de gestão de alimentação:

![Screenshot from 2025-05-15 16-15-54](https://github.com/user-attachments/assets/01e644a7-993c-4b79-bc50-7cb73665d014)


