### PR TITLE
Bugfix/corrige redis param

### DIFF
--- a/sme_sigpae_api/escola/management/commands/atualiza_cache_matriculados_por_faixa.py
+++ b/sme_sigpae_api/escola/management/commands/atualiza_cache_matriculados_por_faixa.py
@@ -25,7 +25,6 @@ redis_connection = redis.StrictRedis(
     host=REDIS_HOST,
     port=REDIS_PORT,
     db=REDIS_DB,
-    charset="utf-8",
     decode_responses=True,
 )
 


### PR DESCRIPTION
# Este PR:
- remove parâmetro `charset` da inicialização do redis, não existente no redis 6