### PR TITLE
Feature/154560 validacao alteracao rpl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,3 +308,6 @@ celerybeat-schedule.dir
 
 requirements.txt
 pgdata/**/*
+
+### IA
+AGENTS.md

--- a/src/cardapio/__tests__/alteracao_tipo_alimentacao/test_urls.py
+++ b/src/cardapio/__tests__/alteracao_tipo_alimentacao/test_urls.py
@@ -1044,11 +1044,13 @@ def _payload_rpl(
     periodo_manha,
     tipo_alimentacao_refeicao,
     tipo_alimentacao_lanche,
+    data_iso="2023-11-18",
 ):
+    data_br = datetime.datetime.strptime(data_iso, "%Y-%m-%d").strftime("%d/%m/%Y")
     return {
         "motivo": str(motivo_rpl.uuid),
-        "data_inicial": "18/11/2023",
-        "data_final": "18/11/2023",
+        "data_inicial": data_br,
+        "data_final": data_br,
         "observacao": "<p>dia do aniversariante</p>",
         "escola": str(escola.uuid),
         "substituicoes": [
@@ -1059,7 +1061,7 @@ def _payload_rpl(
                 "qtd_alunos": "100",
             }
         ],
-        "datas_intervalo": [{"data": "2023-11-18"}],
+        "datas_intervalo": [{"data": data_iso}],
     }
 
 
@@ -1123,15 +1125,65 @@ def test_url_endpoint_alt_card_rpl_com_dia_letivo_sigpae(
 def test_url_endpoint_alt_card_rpl_com_dia_calendario_letivo(
     client_autenticado_vinculo_escola_cardapio,
     motivo_alteracao_cardapio_rpl,
-    escola_com_dias_letivos,
+    escola_com_vinculo_alimentacao,
     periodo_manha,
     tipo_alimentacao,
     tipo_alimentacao_lanche,
 ):
+    baker.make(
+        "DiaCalendario",
+        escola=escola_com_vinculo_alimentacao,
+        data=datetime.date(2023, 11, 15),
+        dia_letivo=True,
+    )
     data = _payload_rpl(
-        escola_com_dias_letivos,
+        escola_com_vinculo_alimentacao,
         motivo_alteracao_cardapio_rpl,
         periodo_manha,
+        tipo_alimentacao,
+        tipo_alimentacao_lanche,
+        "2023-11-15",
+    )
+    response = client_autenticado_vinculo_escola_cardapio.post(
+        f"/{ENDPOINT_ALTERACAO_CARD}/",
+        content_type="application/json",
+        data=json.dumps(data),
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@freeze_time("2023-11-09")
+def test_url_endpoint_alt_card_rpl_inclusao_periodo_nao_autorizado(
+    client_autenticado_vinculo_escola_cardapio,
+    motivo_alteracao_cardapio_rpl,
+    escola_com_vinculo_alimentacao,
+    periodo_manha,
+    periodo_tarde,
+    tipo_alimentacao,
+    tipo_alimentacao_lanche,
+):
+    grupo = baker.make(
+        "GrupoInclusaoAlimentacaoNormal",
+        escola=escola_com_vinculo_alimentacao,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "InclusaoAlimentacaoNormal",
+        grupo_inclusao=grupo,
+        data=datetime.date(2023, 11, 18),
+    )
+    quantidade = baker.make(
+        "QuantidadePorPeriodo",
+        grupo_inclusao_normal=grupo,
+        numero_alunos=100,
+        periodo_escolar=periodo_manha,
+    )
+    quantidade.tipos_alimentacao.set([tipo_alimentacao, tipo_alimentacao_lanche])
+
+    data = _payload_rpl(
+        escola_com_vinculo_alimentacao,
+        motivo_alteracao_cardapio_rpl,
+        periodo_tarde,
         tipo_alimentacao,
         tipo_alimentacao_lanche,
     )
@@ -1140,7 +1192,13 @@ def test_url_endpoint_alt_card_rpl_com_dia_calendario_letivo(
         content_type="application/json",
         data=json.dumps(data),
     )
-    assert response.status_code == status.HTTP_201_CREATED
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "non_field_errors": [
+            "Para o dia 18/11, a inclusão está autorizada somente nos "
+            "períodos MANHA."
+        ]
+    }
 
 
 @freeze_time("2023-11-09")

--- a/src/cardapio/__tests__/alteracao_tipo_alimentacao/test_urls.py
+++ b/src/cardapio/__tests__/alteracao_tipo_alimentacao/test_urls.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 from freezegun import freeze_time
+from model_bakery import baker
 from rest_framework import status
 
 from src.cardapio.__tests__.utils import (
@@ -17,6 +18,7 @@ from src.dados_comuns.constants import (
     SEM_FILTRO,
 )
 from src.dados_comuns.fluxo_status import PedidoAPartirDaEscolaWorkflow
+from src.escola.dias_letivos.models import DiaLetivoSIGPAE
 
 pytestmark = pytest.mark.django_db
 
@@ -1033,4 +1035,151 @@ def test_mesmo_periodo_mesma_data_escola_cadastra_rascunho_deve_permitir_novo_ca
         data=json.dumps(requisicao_alteracao_cardapio_periodo_manha),
     )
 
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def _payload_rpl(
+    escola,
+    motivo_rpl,
+    periodo_manha,
+    tipo_alimentacao_refeicao,
+    tipo_alimentacao_lanche,
+):
+    return {
+        "motivo": str(motivo_rpl.uuid),
+        "data_inicial": "18/11/2023",
+        "data_final": "18/11/2023",
+        "observacao": "<p>dia do aniversariante</p>",
+        "escola": str(escola.uuid),
+        "substituicoes": [
+            {
+                "periodo_escolar": str(periodo_manha.uuid),
+                "tipos_alimentacao_de": [str(tipo_alimentacao_refeicao.uuid)],
+                "tipos_alimentacao_para": [str(tipo_alimentacao_lanche.uuid)],
+                "qtd_alunos": "100",
+            }
+        ],
+        "datas_intervalo": [{"data": "2023-11-18"}],
+    }
+
+
+@freeze_time("2023-11-09")
+def test_url_endpoint_alt_card_rpl_sem_dia_letivo_ou_inclusao_deve_bloquear(
+    client_autenticado_vinculo_escola_cardapio,
+    motivo_alteracao_cardapio_rpl,
+    escola_com_vinculo_alimentacao,
+    periodo_manha,
+    tipo_alimentacao,
+    tipo_alimentacao_lanche,
+):
+    data = _payload_rpl(
+        escola_com_vinculo_alimentacao,
+        motivo_alteracao_cardapio_rpl,
+        periodo_manha,
+        tipo_alimentacao,
+        tipo_alimentacao_lanche,
+    )
+    response = client_autenticado_vinculo_escola_cardapio.post(
+        f"/{ENDPOINT_ALTERACAO_CARD}/",
+        content_type="application/json",
+        data=json.dumps(data),
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "non_field_errors": [
+            "Dia 18/11 não é um dia letivo ou não existe uma inclusão de "
+            "alimentação para a data"
+        ]
+    }
+
+
+@freeze_time("2023-11-09")
+def test_url_endpoint_alt_card_rpl_com_dia_letivo_sigpae(
+    client_autenticado_vinculo_escola_cardapio,
+    motivo_alteracao_cardapio_rpl,
+    escola_com_vinculo_alimentacao,
+    periodo_manha,
+    tipo_alimentacao,
+    tipo_alimentacao_lanche,
+):
+    dia_letivo = baker.make(DiaLetivoSIGPAE, data=datetime.date(2023, 11, 18))
+    dia_letivo.escolas.add(escola_com_vinculo_alimentacao)
+    data = _payload_rpl(
+        escola_com_vinculo_alimentacao,
+        motivo_alteracao_cardapio_rpl,
+        periodo_manha,
+        tipo_alimentacao,
+        tipo_alimentacao_lanche,
+    )
+    response = client_autenticado_vinculo_escola_cardapio.post(
+        f"/{ENDPOINT_ALTERACAO_CARD}/",
+        content_type="application/json",
+        data=json.dumps(data),
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@freeze_time("2023-11-09")
+def test_url_endpoint_alt_card_rpl_com_dia_calendario_letivo(
+    client_autenticado_vinculo_escola_cardapio,
+    motivo_alteracao_cardapio_rpl,
+    escola_com_dias_letivos,
+    periodo_manha,
+    tipo_alimentacao,
+    tipo_alimentacao_lanche,
+):
+    data = _payload_rpl(
+        escola_com_dias_letivos,
+        motivo_alteracao_cardapio_rpl,
+        periodo_manha,
+        tipo_alimentacao,
+        tipo_alimentacao_lanche,
+    )
+    response = client_autenticado_vinculo_escola_cardapio.post(
+        f"/{ENDPOINT_ALTERACAO_CARD}/",
+        content_type="application/json",
+        data=json.dumps(data),
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@freeze_time("2023-11-09")
+def test_url_endpoint_alt_card_rpl_com_inclusao_normal_autorizada(
+    client_autenticado_vinculo_escola_cardapio,
+    motivo_alteracao_cardapio_rpl,
+    escola_com_vinculo_alimentacao,
+    periodo_manha,
+    tipo_alimentacao,
+    tipo_alimentacao_lanche,
+):
+    grupo = baker.make(
+        "GrupoInclusaoAlimentacaoNormal",
+        escola=escola_com_vinculo_alimentacao,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "InclusaoAlimentacaoNormal",
+        grupo_inclusao=grupo,
+        data=datetime.date(2023, 11, 18),
+    )
+    quantidade = baker.make(
+        "QuantidadePorPeriodo",
+        grupo_inclusao_normal=grupo,
+        numero_alunos=100,
+        periodo_escolar=periodo_manha,
+    )
+    quantidade.tipos_alimentacao.set([tipo_alimentacao, tipo_alimentacao_lanche])
+
+    data = _payload_rpl(
+        escola_com_vinculo_alimentacao,
+        motivo_alteracao_cardapio_rpl,
+        periodo_manha,
+        tipo_alimentacao,
+        tipo_alimentacao_lanche,
+    )
+    response = client_autenticado_vinculo_escola_cardapio.post(
+        f"/{ENDPOINT_ALTERACAO_CARD}/",
+        content_type="application/json",
+        data=json.dumps(data),
+    )
     assert response.status_code == status.HTTP_201_CREATED

--- a/src/cardapio/__tests__/alteracao_tipo_alimentacao/test_urls.py
+++ b/src/cardapio/__tests__/alteracao_tipo_alimentacao/test_urls.py
@@ -1241,3 +1241,51 @@ def test_url_endpoint_alt_card_rpl_com_inclusao_normal_autorizada(
         data=json.dumps(data),
     )
     assert response.status_code == status.HTTP_201_CREATED
+
+
+@freeze_time("2023-11-09")
+def test_url_endpoint_alt_card_rpl_inclusao_sem_lanche_para_periodo(
+    client_autenticado_vinculo_escola_cardapio,
+    motivo_alteracao_cardapio_rpl,
+    escola_com_vinculo_alimentacao,
+    periodo_manha,
+    tipo_alimentacao,
+    tipo_alimentacao_lanche,
+):
+    grupo = baker.make(
+        "GrupoInclusaoAlimentacaoNormal",
+        escola=escola_com_vinculo_alimentacao,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "InclusaoAlimentacaoNormal",
+        grupo_inclusao=grupo,
+        data=datetime.date(2023, 11, 18),
+    )
+    quantidade = baker.make(
+        "QuantidadePorPeriodo",
+        grupo_inclusao_normal=grupo,
+        numero_alunos=100,
+        periodo_escolar=periodo_manha,
+    )
+    quantidade.tipos_alimentacao.set([tipo_alimentacao])
+
+    data = _payload_rpl(
+        escola_com_vinculo_alimentacao,
+        motivo_alteracao_cardapio_rpl,
+        periodo_manha,
+        tipo_alimentacao,
+        tipo_alimentacao_lanche,
+    )
+    response = client_autenticado_vinculo_escola_cardapio.post(
+        f"/{ENDPOINT_ALTERACAO_CARD}/",
+        content_type="application/json",
+        data=json.dumps(data),
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "non_field_errors": [
+            "Para o dia 18/11, a inclusão autorizada não possui Refeição e "
+            "Lanche autorizado para o periodo MANHA."
+        ]
+    }

--- a/src/cardapio/__tests__/alteracao_tipo_alimentacao_cei/test_urls.py
+++ b/src/cardapio/__tests__/alteracao_tipo_alimentacao_cei/test_urls.py
@@ -1,4 +1,9 @@
+import datetime
+import json
+
 import pytest
+from freezegun import freeze_time
+from model_bakery import baker
 from rest_framework import status
 
 from src.dados_comuns import constants
@@ -8,6 +13,7 @@ from src.dados_comuns.constants import (
     SEM_FILTRO,
 )
 from src.dados_comuns.fluxo_status import PedidoAPartirDaEscolaWorkflow
+from src.escola.dias_letivos.models import DiaLetivoSIGPAE
 
 pytestmark = pytest.mark.django_db
 
@@ -81,3 +87,79 @@ def test_url_alteracoes_cardapio_cei_dre(client_autenticado_vinculo_dre_inclusao
     assert "count" not in data
     assert "results" in data
     assert isinstance(data["results"], list)
+
+
+def _payload_rpl_cei(
+    escola_cei,
+    motivo_rpl,
+    periodo_escolar,
+    tipo_alimentacao_refeicao,
+    tipo_alimentacao_lanche,
+):
+    return {
+        "escola": str(escola_cei.uuid),
+        "motivo": str(motivo_rpl.uuid),
+        "data": "18/11/2023",
+        "substituicoes": [
+            {
+                "periodo_escolar": str(periodo_escolar.uuid),
+                "tipos_alimentacao_de": [str(tipo_alimentacao_refeicao.uuid)],
+                "tipo_alimentacao_para": str(tipo_alimentacao_lanche.uuid),
+                "faixas_etarias": [],
+            }
+        ],
+    }
+
+
+@freeze_time("2023-11-09")
+def test_alteracao_cei_rpl_sem_dia_letivo_ou_inclusao_deve_bloquear(
+    client_autenticado_vinculo_escola_cei_cardapio,
+    escola_cei,
+    motivo_alteracao_cardapio_rpl,
+    periodo_escolar,
+    tipo_alimentacao,
+    tipo_alimentacao_lanche,
+):
+    data = _payload_rpl_cei(
+        escola_cei,
+        motivo_alteracao_cardapio_rpl,
+        periodo_escolar,
+        tipo_alimentacao,
+        tipo_alimentacao_lanche,
+    )
+    response = client_autenticado_vinculo_escola_cei_cardapio.post(
+        f"/{ENDPOINT_ALTERACAO_CARD_CEI}/",
+        content_type="application/json",
+        data=json.dumps(data),
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["data"] == [
+        "Dia 18/11 não é um dia letivo ou não existe uma inclusão de "
+        "alimentação para a data"
+    ]
+
+
+@freeze_time("2023-11-09")
+def test_alteracao_cei_rpl_com_dia_letivo_sigpae(
+    client_autenticado_vinculo_escola_cei_cardapio,
+    escola_cei,
+    motivo_alteracao_cardapio_rpl,
+    periodo_escolar,
+    tipo_alimentacao,
+    tipo_alimentacao_lanche,
+):
+    dia_letivo = baker.make(DiaLetivoSIGPAE, data=datetime.date(2023, 11, 18))
+    dia_letivo.escolas.add(escola_cei)
+    data = _payload_rpl_cei(
+        escola_cei,
+        motivo_alteracao_cardapio_rpl,
+        periodo_escolar,
+        tipo_alimentacao,
+        tipo_alimentacao_lanche,
+    )
+    response = client_autenticado_vinculo_escola_cei_cardapio.post(
+        f"/{ENDPOINT_ALTERACAO_CARD_CEI}/",
+        content_type="application/json",
+        data=json.dumps(data),
+    )
+    assert response.status_code == status.HTTP_201_CREATED

--- a/src/cardapio/__tests__/alteracao_tipo_alimentacao_cemei/test_urls.py
+++ b/src/cardapio/__tests__/alteracao_tipo_alimentacao_cemei/test_urls.py
@@ -1,7 +1,9 @@
+import datetime
 import json
 
 import pytest
 from freezegun import freeze_time
+from model_bakery import baker
 from rest_framework import status
 
 from src.dados_comuns import constants
@@ -10,6 +12,7 @@ from src.dados_comuns.constants import (
     PEDIDOS_DRE,
     SEM_FILTRO,
 )
+from src.escola.dias_letivos.models import DiaLetivoSIGPAE
 
 pytestmark = pytest.mark.django_db
 
@@ -157,3 +160,93 @@ def test_url_alteracoes_cardapio_cemei_dre(client_autenticado_vinculo_dre_escola
     assert "count" not in data
     assert "results" in data
     assert isinstance(data["results"], list)
+
+
+def _payload_rpl_cemei(
+    escola_cemei,
+    motivo_rpl,
+    periodo_escolar,
+    tipo_alimentacao_refeicao,
+    tipo_alimentacao_lanche,
+    faixas_etarias_ativas,
+):
+    return {
+        "escola": str(escola_cemei.uuid),
+        "motivo": str(motivo_rpl.uuid),
+        "alunos_cei_e_ou_emei": "CEI",
+        "alterar_dia": "30/07/2023",
+        "substituicoes_cemei_cei_periodo_escolar": [
+            {
+                "periodo_escolar": str(periodo_escolar.uuid),
+                "tipos_alimentacao_de": [str(tipo_alimentacao_refeicao.uuid)],
+                "tipos_alimentacao_para": [str(tipo_alimentacao_lanche.uuid)],
+                "faixas_etarias": [
+                    {
+                        "faixa_etaria": str(faixas_etarias_ativas[0].uuid),
+                        "quantidade": "12",
+                        "matriculados_quando_criado": 33,
+                    }
+                ],
+            }
+        ],
+        "substituicoes_cemei_emei_periodo_escolar": [],
+        "observacao": "<p>teste</p>",
+    }
+
+
+@freeze_time("2023-07-14")
+def test_create_alteracao_cemei_rpl_sem_dia_letivo_ou_inclusao_deve_bloquear(
+    client_autenticado_vinculo_escola_cemei,
+    escola_cemei,
+    motivo_alteracao_cardapio_rpl,
+    periodo_escolar,
+    tipo_alimentacao,
+    tipo_alimentacao_lanche,
+    faixas_etarias_ativas,
+):
+    data = _payload_rpl_cemei(
+        escola_cemei,
+        motivo_alteracao_cardapio_rpl,
+        periodo_escolar,
+        tipo_alimentacao,
+        tipo_alimentacao_lanche,
+        faixas_etarias_ativas,
+    )
+    response = client_autenticado_vinculo_escola_cemei.post(
+        "/alteracoes-cardapio-cemei/",
+        content_type="application/json",
+        data=json.dumps(data),
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == [
+        "Dia 30/07 não é um dia letivo ou não existe uma inclusão de "
+        "alimentação para a data"
+    ]
+
+
+@freeze_time("2023-07-14")
+def test_create_alteracao_cemei_rpl_com_dia_letivo_sigpae(
+    client_autenticado_vinculo_escola_cemei,
+    escola_cemei,
+    motivo_alteracao_cardapio_rpl,
+    periodo_escolar,
+    tipo_alimentacao,
+    tipo_alimentacao_lanche,
+    faixas_etarias_ativas,
+):
+    dia_letivo = baker.make(DiaLetivoSIGPAE, data=datetime.date(2023, 7, 30))
+    dia_letivo.escolas.add(escola_cemei)
+    data = _payload_rpl_cemei(
+        escola_cemei,
+        motivo_alteracao_cardapio_rpl,
+        periodo_escolar,
+        tipo_alimentacao,
+        tipo_alimentacao_lanche,
+        faixas_etarias_ativas,
+    )
+    response = client_autenticado_vinculo_escola_cemei.post(
+        "/alteracoes-cardapio-cemei/",
+        content_type="application/json",
+        data=json.dumps(data),
+    )
+    assert response.status_code == status.HTTP_201_CREATED

--- a/src/cardapio/__tests__/alteracao_tipo_alimentacao_cemei/test_urls.py
+++ b/src/cardapio/__tests__/alteracao_tipo_alimentacao_cemei/test_urls.py
@@ -250,3 +250,50 @@ def test_create_alteracao_cemei_rpl_com_dia_letivo_sigpae(
         data=json.dumps(data),
     )
     assert response.status_code == status.HTTP_201_CREATED
+
+
+@freeze_time("2023-07-14")
+def test_create_alteracao_cemei_rpl_cei_com_inclusao_somente_emei_deve_bloquear(
+    client_autenticado_vinculo_escola_cemei,
+    escola_cemei,
+    motivo_alteracao_cardapio_rpl,
+    periodo_escolar,
+    tipo_alimentacao,
+    tipo_alimentacao_lanche,
+    faixas_etarias_ativas,
+):
+    inclusao = baker.make(
+        "InclusaoDeAlimentacaoCEMEI",
+        escola=escola_cemei,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "DiasMotivosInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        data=datetime.date(2023, 7, 30),
+    )
+    quantidade = baker.make(
+        "QuantidadeDeAlunosEMEIInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        quantidade_alunos=10,
+        periodo_escolar=periodo_escolar,
+    )
+    quantidade.tipos_alimentacao.set([tipo_alimentacao, tipo_alimentacao_lanche])
+
+    data = _payload_rpl_cemei(
+        escola_cemei,
+        motivo_alteracao_cardapio_rpl,
+        periodo_escolar,
+        tipo_alimentacao,
+        tipo_alimentacao_lanche,
+        faixas_etarias_ativas,
+    )
+    response = client_autenticado_vinculo_escola_cemei.post(
+        "/alteracoes-cardapio-cemei/",
+        content_type="application/json",
+        data=json.dumps(data),
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == [
+        "Inclusão autorizada para o dia 30/07 somente nos para EMEI"
+    ]

--- a/src/cardapio/__tests__/alteracao_tipo_alimentacao_cemei/test_urls.py
+++ b/src/cardapio/__tests__/alteracao_tipo_alimentacao_cemei/test_urls.py
@@ -294,6 +294,4 @@ def test_create_alteracao_cemei_rpl_cei_com_inclusao_somente_emei_deve_bloquear(
         data=json.dumps(data),
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json() == [
-        "Inclusão autorizada para o dia 30/07 somente nos para EMEI"
-    ]
+    assert response.json() == ["Inclusão autorizada para o dia 30/07 somente para EMEI"]

--- a/src/cardapio/__tests__/conftest.py
+++ b/src/cardapio/__tests__/conftest.py
@@ -34,6 +34,11 @@ def tipo_alimentacao():
 
 
 @pytest.fixture
+def tipo_alimentacao_lanche():
+    return baker.make("cardapio.TipoAlimentacao", nome="Lanche")
+
+
+@pytest.fixture
 def tipo_alimentacao_lanche_emergencial():
     return baker.make("cardapio.TipoAlimentacao", nome="Lanche Emergencial")
 
@@ -270,6 +275,11 @@ def motivo_alteracao_cardapio_lanche_emergencial():
         nome="Lanche Emergencial",
         uuid="19d0bca9-3cfe-4542-869e-185d580fef06",
     )
+
+
+@pytest.fixture
+def motivo_alteracao_cardapio_rpl():
+    return baker.make(MotivoAlteracaoCardapio, nome="RPL - Refeição por Lanche")
 
 
 @pytest.fixture

--- a/src/cardapio/alteracao_tipo_alimentacao/api/serializers_create.py
+++ b/src/cardapio/alteracao_tipo_alimentacao/api/serializers_create.py
@@ -270,15 +270,21 @@ class AlteracaoCardapioSerializerCreate(AlteracaoCardapioSerializerCreateBase):
             deve_pedir_com_antecedencia(attrs["data_inicial"])
         if attrs["motivo"].nome == "RPL - Refeição por Lanche":
             valida_duplicidade_solicitacoes(attrs)
-            periodos = [
-                substituicao["periodo_escolar"].nome
+            periodos_lanches = [
+                {
+                    "periodo": substituicao["periodo_escolar"].nome,
+                    "lanches": [
+                        tipo.nome
+                        for tipo in substituicao.get("tipos_alimentacao_para", [])
+                    ],
+                }
                 for substituicao in attrs["substituicoes"]
             ]
             valida_dia_letivo_ou_inclusao_alimentacao_rpl(
                 escola,
                 attrs["data_inicial"],
                 GrupoInclusaoAlimentacaoNormal,
-                periodos,
+                periodos_lanches,
             )
         deve_ser_no_mesmo_ano_corrente(attrs["data_inicial"])
 

--- a/src/cardapio/alteracao_tipo_alimentacao/api/serializers_create.py
+++ b/src/cardapio/alteracao_tipo_alimentacao/api/serializers_create.py
@@ -270,8 +270,15 @@ class AlteracaoCardapioSerializerCreate(AlteracaoCardapioSerializerCreateBase):
             deve_pedir_com_antecedencia(attrs["data_inicial"])
         if attrs["motivo"].nome == "RPL - Refeição por Lanche":
             valida_duplicidade_solicitacoes(attrs)
+            periodos = [
+                substituicao["periodo_escolar"].nome
+                for substituicao in attrs["substituicoes"]
+            ]
             valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-                escola, attrs["data_inicial"], GrupoInclusaoAlimentacaoNormal
+                escola,
+                attrs["data_inicial"],
+                GrupoInclusaoAlimentacaoNormal,
+                periodos,
             )
         deve_ser_no_mesmo_ano_corrente(attrs["data_inicial"])
 

--- a/src/cardapio/alteracao_tipo_alimentacao/api/serializers_create.py
+++ b/src/cardapio/alteracao_tipo_alimentacao/api/serializers_create.py
@@ -18,10 +18,12 @@ from src.dados_comuns.validators import (
     deve_ser_no_mesmo_ano_corrente,
     nao_pode_ser_no_passado,
     valida_datas_alteracao_cardapio,
+    valida_dia_letivo_ou_inclusao_alimentacao_rpl,
     valida_duplicidade_solicitacoes,
 )
 from src.escola.models import DiaCalendario, Escola, PeriodoEscolar
 from src.escola.utils import eh_dia_sem_atividade_escolar
+from src.inclusao_alimentacao.models import GrupoInclusaoAlimentacaoNormal
 
 
 class SubstituicoesAlimentacaoNoPeriodoEscolarSerializerCreateBase(
@@ -268,6 +270,9 @@ class AlteracaoCardapioSerializerCreate(AlteracaoCardapioSerializerCreateBase):
             deve_pedir_com_antecedencia(attrs["data_inicial"])
         if attrs["motivo"].nome == "RPL - Refeição por Lanche":
             valida_duplicidade_solicitacoes(attrs)
+            valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+                escola, attrs["data_inicial"], GrupoInclusaoAlimentacaoNormal
+            )
         deve_ser_no_mesmo_ano_corrente(attrs["data_inicial"])
 
         return attrs

--- a/src/cardapio/alteracao_tipo_alimentacao_cei/api/serializers_create.py
+++ b/src/cardapio/alteracao_tipo_alimentacao_cei/api/serializers_create.py
@@ -17,9 +17,11 @@ from src.dados_comuns.validators import (
     deve_pedir_com_antecedencia,
     deve_ser_no_mesmo_ano_corrente,
     nao_pode_ser_no_passado,
+    valida_dia_letivo_ou_inclusao_alimentacao_rpl,
     valida_duplicidade_solicitacoes_cei,
 )
-from src.escola.models import FaixaEtaria
+from src.escola.models import Escola, FaixaEtaria
+from src.inclusao_alimentacao.models import InclusaoAlimentacaoDaCEI
 
 
 class FaixaEtariaSubstituicaoAlimentacaoCEISerializerCreate(
@@ -145,6 +147,10 @@ class AlteracaoCardapioCEISerializerCreate(AlteracaoCardapioSerializerCreateBase
         motivo = MotivoAlteracaoCardapio.objects.filter(uuid=attrs["motivo"]).first()
         if motivo and motivo.nome == "RPL - Refeição por Lanche":
             valida_duplicidade_solicitacoes_cei(attrs, data)
+            escola = Escola.objects.get(uuid=attrs["escola"])
+            valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+                escola, data, InclusaoAlimentacaoDaCEI
+            )
         return data
 
     class Meta:

--- a/src/cardapio/alteracao_tipo_alimentacao_cei/api/serializers_create.py
+++ b/src/cardapio/alteracao_tipo_alimentacao_cei/api/serializers_create.py
@@ -20,7 +20,7 @@ from src.dados_comuns.validators import (
     valida_dia_letivo_ou_inclusao_alimentacao_rpl,
     valida_duplicidade_solicitacoes_cei,
 )
-from src.escola.models import Escola, FaixaEtaria
+from src.escola.models import Escola, FaixaEtaria, PeriodoEscolar
 from src.inclusao_alimentacao.models import InclusaoAlimentacaoDaCEI
 
 
@@ -148,8 +148,15 @@ class AlteracaoCardapioCEISerializerCreate(AlteracaoCardapioSerializerCreateBase
         if motivo and motivo.nome == "RPL - Refeição por Lanche":
             valida_duplicidade_solicitacoes_cei(attrs, data)
             escola = Escola.objects.get(uuid=attrs["escola"])
+            periodos = []
+            for substituicao in attrs.get("substituicoes", []):
+                periodo_uuid = substituicao.get("periodo_escolar")
+                if periodo_uuid:
+                    periodo = PeriodoEscolar.objects.filter(uuid=periodo_uuid).first()
+                    if periodo:
+                        periodos.append(periodo.nome)
             valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-                escola, data, InclusaoAlimentacaoDaCEI
+                escola, data, InclusaoAlimentacaoDaCEI, periodos
             )
         return data
 

--- a/src/cardapio/alteracao_tipo_alimentacao_cei/api/serializers_create.py
+++ b/src/cardapio/alteracao_tipo_alimentacao_cei/api/serializers_create.py
@@ -148,15 +148,25 @@ class AlteracaoCardapioCEISerializerCreate(AlteracaoCardapioSerializerCreateBase
         if motivo and motivo.nome == "RPL - Refeição por Lanche":
             valida_duplicidade_solicitacoes_cei(attrs, data)
             escola = Escola.objects.get(uuid=attrs["escola"])
-            periodos = []
+            periodos_lanches = []
             for substituicao in attrs.get("substituicoes", []):
                 periodo_uuid = substituicao.get("periodo_escolar")
-                if periodo_uuid:
-                    periodo = PeriodoEscolar.objects.filter(uuid=periodo_uuid).first()
-                    if periodo:
-                        periodos.append(periodo.nome)
+                periodo = (
+                    PeriodoEscolar.objects.filter(uuid=periodo_uuid).first()
+                    if periodo_uuid
+                    else None
+                )
+                if not periodo:
+                    continue
+                lanches = []
+                para_uuid = substituicao.get("tipo_alimentacao_para")
+                if para_uuid:
+                    para = TipoAlimentacao.objects.filter(uuid=para_uuid).first()
+                    if para:
+                        lanches.append(para.nome)
+                periodos_lanches.append({"periodo": periodo.nome, "lanches": lanches})
             valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-                escola, data, InclusaoAlimentacaoDaCEI, periodos
+                escola, data, InclusaoAlimentacaoDaCEI, periodos_lanches
             )
         return data
 

--- a/src/cardapio/alteracao_tipo_alimentacao_cei/api/serializers_create.py
+++ b/src/cardapio/alteracao_tipo_alimentacao_cei/api/serializers_create.py
@@ -20,7 +20,7 @@ from src.dados_comuns.validators import (
     valida_dia_letivo_ou_inclusao_alimentacao_rpl,
     valida_duplicidade_solicitacoes_cei,
 )
-from src.escola.models import Escola, FaixaEtaria, PeriodoEscolar
+from src.escola.models import Escola, FaixaEtaria
 from src.inclusao_alimentacao.models import InclusaoAlimentacaoDaCEI
 
 
@@ -148,25 +148,8 @@ class AlteracaoCardapioCEISerializerCreate(AlteracaoCardapioSerializerCreateBase
         if motivo and motivo.nome == "RPL - Refeição por Lanche":
             valida_duplicidade_solicitacoes_cei(attrs, data)
             escola = Escola.objects.get(uuid=attrs["escola"])
-            periodos_lanches = []
-            for substituicao in attrs.get("substituicoes", []):
-                periodo_uuid = substituicao.get("periodo_escolar")
-                periodo = (
-                    PeriodoEscolar.objects.filter(uuid=periodo_uuid).first()
-                    if periodo_uuid
-                    else None
-                )
-                if not periodo:
-                    continue
-                lanches = []
-                para_uuid = substituicao.get("tipo_alimentacao_para")
-                if para_uuid:
-                    para = TipoAlimentacao.objects.filter(uuid=para_uuid).first()
-                    if para:
-                        lanches.append(para.nome)
-                periodos_lanches.append({"periodo": periodo.nome, "lanches": lanches})
             valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-                escola, data, InclusaoAlimentacaoDaCEI, periodos_lanches
+                escola, data, InclusaoAlimentacaoDaCEI
             )
         return data
 

--- a/src/cardapio/alteracao_tipo_alimentacao_cemei/api/serializers_create.py
+++ b/src/cardapio/alteracao_tipo_alimentacao_cemei/api/serializers_create.py
@@ -335,36 +335,24 @@ class AlteracaoCardapioCEMEISerializerCreate(serializers.ModelSerializer):
         motivo = validated_data.get("motivo", None)
         if motivo and motivo.nome == "RPL - Refeição por Lanche":
             valida_duplicidade_solicitacoes_cemei(validated_data)
-            periodos_lanches = []
-            for substituicao in validated_data.get(
-                "substituicoes_cemei_cei_periodo_escolar", []
-            ):
-                periodos_lanches.append(
-                    {
-                        "periodo": substituicao["periodo_escolar"].nome,
-                        "lanches": [
-                            tipo.nome
-                            for tipo in substituicao.get("tipos_alimentacao_para", [])
-                        ],
-                    }
+            periodos_lanches_emei = [
+                {
+                    "periodo": substituicao["periodo_escolar"].nome,
+                    "lanches": [
+                        tipo.nome
+                        for tipo in substituicao.get("tipos_alimentacao_para", [])
+                    ],
+                }
+                for substituicao in validated_data.get(
+                    "substituicoes_cemei_emei_periodo_escolar", []
                 )
-            for substituicao in validated_data.get(
-                "substituicoes_cemei_emei_periodo_escolar", []
-            ):
-                periodos_lanches.append(
-                    {
-                        "periodo": substituicao["periodo_escolar"].nome,
-                        "lanches": [
-                            tipo.nome
-                            for tipo in substituicao.get("tipos_alimentacao_para", [])
-                        ],
-                    }
-                )
+            ]
             valida_dia_letivo_ou_inclusao_alimentacao_rpl(
                 validated_data["escola"],
                 validated_data["alterar_dia"],
                 InclusaoDeAlimentacaoCEMEI,
-                periodos_lanches,
+                periodos_lanches_emei,
+                validated_data.get("alunos_cei_e_ou_emei"),
             )
         substituicoes_cemei_cei_periodo_escolar = validated_data.pop(
             "substituicoes_cemei_cei_periodo_escolar", []

--- a/src/cardapio/alteracao_tipo_alimentacao_cemei/api/serializers_create.py
+++ b/src/cardapio/alteracao_tipo_alimentacao_cemei/api/serializers_create.py
@@ -335,22 +335,36 @@ class AlteracaoCardapioCEMEISerializerCreate(serializers.ModelSerializer):
         motivo = validated_data.get("motivo", None)
         if motivo and motivo.nome == "RPL - Refeição por Lanche":
             valida_duplicidade_solicitacoes_cemei(validated_data)
-            periodos = [
-                substituicao["periodo_escolar"].nome
-                for substituicao in validated_data.get(
-                    "substituicoes_cemei_cei_periodo_escolar", []
+            periodos_lanches = []
+            for substituicao in validated_data.get(
+                "substituicoes_cemei_cei_periodo_escolar", []
+            ):
+                periodos_lanches.append(
+                    {
+                        "periodo": substituicao["periodo_escolar"].nome,
+                        "lanches": [
+                            tipo.nome
+                            for tipo in substituicao.get("tipos_alimentacao_para", [])
+                        ],
+                    }
                 )
-            ] + [
-                substituicao["periodo_escolar"].nome
-                for substituicao in validated_data.get(
-                    "substituicoes_cemei_emei_periodo_escolar", []
+            for substituicao in validated_data.get(
+                "substituicoes_cemei_emei_periodo_escolar", []
+            ):
+                periodos_lanches.append(
+                    {
+                        "periodo": substituicao["periodo_escolar"].nome,
+                        "lanches": [
+                            tipo.nome
+                            for tipo in substituicao.get("tipos_alimentacao_para", [])
+                        ],
+                    }
                 )
-            ]
             valida_dia_letivo_ou_inclusao_alimentacao_rpl(
                 validated_data["escola"],
                 validated_data["alterar_dia"],
                 InclusaoDeAlimentacaoCEMEI,
-                periodos,
+                periodos_lanches,
             )
         substituicoes_cemei_cei_periodo_escolar = validated_data.pop(
             "substituicoes_cemei_cei_periodo_escolar", []

--- a/src/cardapio/alteracao_tipo_alimentacao_cemei/api/serializers_create.py
+++ b/src/cardapio/alteracao_tipo_alimentacao_cemei/api/serializers_create.py
@@ -19,9 +19,11 @@ from src.dados_comuns.validators import (
     deve_pedir_com_antecedencia,
     deve_ser_no_mesmo_ano_corrente,
     nao_pode_ser_no_passado,
+    valida_dia_letivo_ou_inclusao_alimentacao_rpl,
     valida_duplicidade_solicitacoes_cemei,
 )
 from src.escola.models import Escola, FaixaEtaria, PeriodoEscolar
+from src.inclusao_alimentacao.models import InclusaoDeAlimentacaoCEMEI
 
 
 class FaixaEtariaSubstituicaoAlimentacaoCEMEICEICreateSerializer(
@@ -333,6 +335,11 @@ class AlteracaoCardapioCEMEISerializerCreate(serializers.ModelSerializer):
         motivo = validated_data.get("motivo", None)
         if motivo and motivo.nome == "RPL - Refeição por Lanche":
             valida_duplicidade_solicitacoes_cemei(validated_data)
+            valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+                validated_data["escola"],
+                validated_data["alterar_dia"],
+                InclusaoDeAlimentacaoCEMEI,
+            )
         substituicoes_cemei_cei_periodo_escolar = validated_data.pop(
             "substituicoes_cemei_cei_periodo_escolar", []
         )

--- a/src/cardapio/alteracao_tipo_alimentacao_cemei/api/serializers_create.py
+++ b/src/cardapio/alteracao_tipo_alimentacao_cemei/api/serializers_create.py
@@ -335,10 +335,22 @@ class AlteracaoCardapioCEMEISerializerCreate(serializers.ModelSerializer):
         motivo = validated_data.get("motivo", None)
         if motivo and motivo.nome == "RPL - Refeição por Lanche":
             valida_duplicidade_solicitacoes_cemei(validated_data)
+            periodos = [
+                substituicao["periodo_escolar"].nome
+                for substituicao in validated_data.get(
+                    "substituicoes_cemei_cei_periodo_escolar", []
+                )
+            ] + [
+                substituicao["periodo_escolar"].nome
+                for substituicao in validated_data.get(
+                    "substituicoes_cemei_emei_periodo_escolar", []
+                )
+            ]
             valida_dia_letivo_ou_inclusao_alimentacao_rpl(
                 validated_data["escola"],
                 validated_data["alterar_dia"],
                 InclusaoDeAlimentacaoCEMEI,
+                periodos,
             )
         substituicoes_cemei_cei_periodo_escolar = validated_data.pop(
             "substituicoes_cemei_cei_periodo_escolar", []

--- a/src/dados_comuns/__tests__/test_validators.py
+++ b/src/dados_comuns/__tests__/test_validators.py
@@ -610,6 +610,66 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_inclusao_cemei(escola):
             data,
             InclusaoDeAlimentacaoCEMEI,
             [{"periodo": "MANHA", "lanches": ["Lanche"]}],
+            "EMEI",
         )
         is True
     )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_cemei_parte_cei(escola):
+    data = datetime.date(2024, 4, 10)
+    inclusao = baker.make(
+        "InclusaoDeAlimentacaoCEMEI",
+        escola=escola,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "DiasMotivosInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        data=data,
+    )
+    faixa = baker.make("FaixaEtaria")
+    periodo = baker.make("PeriodoEscolar", nome="MANHA")
+    baker.make(
+        "QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        faixa_etaria=faixa,
+        quantidade_alunos=10,
+        periodo_escolar=periodo,
+    )
+    assert (
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, InclusaoDeAlimentacaoCEMEI, [], "CEI"
+        )
+        is True
+    )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_cemei_parte_errada(escola):
+    data = datetime.date(2024, 4, 10)
+    inclusao = baker.make(
+        "InclusaoDeAlimentacaoCEMEI",
+        escola=escola,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "DiasMotivosInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        data=data,
+    )
+    faixa = baker.make("FaixaEtaria")
+    periodo = baker.make("PeriodoEscolar", nome="MANHA")
+    baker.make(
+        "QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        faixa_etaria=faixa,
+        quantidade_alunos=10,
+        periodo_escolar=periodo,
+    )
+    with pytest.raises(
+        ValidationError,
+        match="somente nos para CEI",
+    ):
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, InclusaoDeAlimentacaoCEMEI, [], "EMEI"
+        )

--- a/src/dados_comuns/__tests__/test_validators.py
+++ b/src/dados_comuns/__tests__/test_validators.py
@@ -668,8 +668,68 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_cemei_parte_errada(escola
     )
     with pytest.raises(
         ValidationError,
-        match="somente nos para CEI",
+        match="somente para CEI",
     ):
         valida_dia_letivo_ou_inclusao_alimentacao_rpl(
             escola, data, InclusaoDeAlimentacaoCEMEI, [], "EMEI"
+        )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_cemei_todos_sem_emei(escola):
+    data = datetime.date(2024, 4, 10)
+    inclusao = baker.make(
+        "InclusaoDeAlimentacaoCEMEI",
+        escola=escola,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "DiasMotivosInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        data=data,
+    )
+    faixa = baker.make("FaixaEtaria")
+    periodo = baker.make("PeriodoEscolar", nome="MANHA")
+    baker.make(
+        "QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        faixa_etaria=faixa,
+        quantidade_alunos=10,
+        periodo_escolar=periodo,
+    )
+    with pytest.raises(
+        ValidationError,
+        match="somente para CEI",
+    ):
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, InclusaoDeAlimentacaoCEMEI, [], "TODOS"
+        )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_cemei_escopo_nulo(escola):
+    data = datetime.date(2024, 4, 10)
+    inclusao = baker.make(
+        "InclusaoDeAlimentacaoCEMEI",
+        escola=escola,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "DiasMotivosInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        data=data,
+    )
+    faixa = baker.make("FaixaEtaria")
+    periodo = baker.make("PeriodoEscolar", nome="MANHA")
+    baker.make(
+        "QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        faixa_etaria=faixa,
+        quantidade_alunos=10,
+        periodo_escolar=periodo,
+    )
+    with pytest.raises(
+        ValidationError,
+        match="somente para CEI",
+    ):
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, InclusaoDeAlimentacaoCEMEI, [], None
         )

--- a/src/dados_comuns/__tests__/test_validators.py
+++ b/src/dados_comuns/__tests__/test_validators.py
@@ -289,6 +289,26 @@ def _make_inclusao_normal_autorizada_com_refeicao_e_lanche(escola, data):
     return grupo
 
 
+def _make_inclusao_normal_autorizada_periodos(escola, data, periodo_nomes):
+    grupo = baker.make(
+        "GrupoInclusaoAlimentacaoNormal",
+        escola=escola,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make("InclusaoAlimentacaoNormal", grupo_inclusao=grupo, data=data)
+    refeicao = baker.make("TipoAlimentacao", nome="Refeição")
+    lanche = baker.make("TipoAlimentacao", nome="Lanche")
+    for nome in periodo_nomes:
+        quantidade = baker.make(
+            "QuantidadePorPeriodo",
+            grupo_inclusao_normal=grupo,
+            numero_alunos=100,
+            periodo_escolar=baker.make("PeriodoEscolar", nome=nome),
+        )
+        quantidade.tipos_alimentacao.set([refeicao, lanche])
+    return grupo
+
+
 def test_unidade_tem_dia_letivo_sigpae_escola_dentro(escola):
     data = datetime.date(2024, 4, 10)
     dia_letivo = baker.make(DiaLetivoSIGPAE, data=data)
@@ -451,6 +471,52 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_com_inclusao(escola):
     assert (
         valida_dia_letivo_ou_inclusao_alimentacao_rpl(
             escola, data, GrupoInclusaoAlimentacaoNormal
+        )
+        is True
+    )
+
+
+def test_valida_rpl_inclusao_periodo_contido(escola):
+    data = datetime.date(2024, 4, 10)
+    _make_inclusao_normal_autorizada_periodos(escola, data, ["MANHA"])
+    assert (
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal, ["MANHA"]
+        )
+        is True
+    )
+
+
+def test_valida_rpl_inclusao_periodo_nao_contido(escola):
+    data = datetime.date(2024, 4, 10)
+    _make_inclusao_normal_autorizada_periodos(escola, data, ["MANHA"])
+    with pytest.raises(
+        ValidationError,
+        match="somente nos períodos MANHA",
+    ):
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal, ["TARDE"]
+        )
+
+
+def test_valida_rpl_inclusao_um_periodo_nao_contido_entre_varios(escola):
+    data = datetime.date(2024, 4, 10)
+    _make_inclusao_normal_autorizada_periodos(escola, data, ["MANHA", "TARDE"])
+    with pytest.raises(
+        ValidationError,
+        match="somente nos períodos MANHA e TARDE",
+    ):
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal, ["MANHA", "INTEGRAL"]
+        )
+
+
+def test_valida_rpl_inclusao_todos_periodos_contidos(escola):
+    data = datetime.date(2024, 4, 10)
+    _make_inclusao_normal_autorizada_periodos(escola, data, ["MANHA", "TARDE"])
+    assert (
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal, ["MANHA", "TARDE"]
         )
         is True
     )

--- a/src/dados_comuns/__tests__/test_validators.py
+++ b/src/dados_comuns/__tests__/test_validators.py
@@ -24,7 +24,6 @@ from ..validators import (
     deve_ter_extensao_xls_xlsx_pdf,
     dia_util,
     escola_tem_dia_letivo_no_calendario,
-    existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche,
     nao_pode_ser_feriado,
     nao_pode_ser_no_passado,
     objeto_nao_deve_ter_duplicidade,
@@ -270,42 +269,30 @@ def test_valida_duplicidade_solicitacoes_duplicada_cei(
         valida_duplicidade_solicitacoes_cei(solicitacao_substituicao_cardapio_cei, data)
 
 
-def _make_inclusao_normal_autorizada_com_refeicao_e_lanche(escola, data):
+def _make_inclusao_normal_autorizada(escola, data, periodo_tipos):
+    """Cria uma inclusão normal autorizada com períodos e tipos informados.
+
+    Args:
+        escola (Escola): Escola da inclusão.
+        data (datetime.date): Data da inclusão.
+        periodo_tipos (dict): Mapeamento ``{periodo_nome: [tipo_nomes]}``.
+    """
     grupo = baker.make(
         "GrupoInclusaoAlimentacaoNormal",
         escola=escola,
         status="CODAE_AUTORIZADO",
     )
     baker.make("InclusaoAlimentacaoNormal", grupo_inclusao=grupo, data=data)
-    refeicao = baker.make("TipoAlimentacao", nome="Refeição")
-    lanche = baker.make("TipoAlimentacao", nome="Lanche")
-    quantidade = baker.make(
-        "QuantidadePorPeriodo",
-        grupo_inclusao_normal=grupo,
-        numero_alunos=100,
-        periodo_escolar=baker.make("PeriodoEscolar"),
-    )
-    quantidade.tipos_alimentacao.set([refeicao, lanche])
-    return grupo
-
-
-def _make_inclusao_normal_autorizada_periodos(escola, data, periodo_nomes):
-    grupo = baker.make(
-        "GrupoInclusaoAlimentacaoNormal",
-        escola=escola,
-        status="CODAE_AUTORIZADO",
-    )
-    baker.make("InclusaoAlimentacaoNormal", grupo_inclusao=grupo, data=data)
-    refeicao = baker.make("TipoAlimentacao", nome="Refeição")
-    lanche = baker.make("TipoAlimentacao", nome="Lanche")
-    for nome in periodo_nomes:
+    for periodo_nome, tipo_nomes in periodo_tipos.items():
         quantidade = baker.make(
             "QuantidadePorPeriodo",
             grupo_inclusao_normal=grupo,
             numero_alunos=100,
-            periodo_escolar=baker.make("PeriodoEscolar", nome=nome),
+            periodo_escolar=baker.make("PeriodoEscolar", nome=periodo_nome),
         )
-        quantidade.tipos_alimentacao.set([refeicao, lanche])
+        quantidade.tipos_alimentacao.set(
+            [baker.make("TipoAlimentacao", nome=nome) for nome in tipo_nomes]
+        )
     return grupo
 
 
@@ -352,41 +339,6 @@ def test_unidade_tem_dia_letivo_sigpae_outra_escola(escola):
     dia_letivo = baker.make(DiaLetivoSIGPAE, data=data)
     dia_letivo.escolas.add(outra_escola)
     assert unidade_tem_dia_letivo_sigpae(escola, data) is False
-
-
-def test_existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(escola):
-    data = datetime.date(2024, 4, 10)
-    _make_inclusao_normal_autorizada_com_refeicao_e_lanche(escola, data)
-    assert (
-        existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(
-            escola, data, GrupoInclusaoAlimentacaoNormal
-        )
-        is True
-    )
-
-
-def test_existe_inclusao_alimentacao_autorizada_sem_lanche(escola):
-    data = datetime.date(2024, 4, 10)
-    grupo = baker.make(
-        "GrupoInclusaoAlimentacaoNormal",
-        escola=escola,
-        status="CODAE_AUTORIZADO",
-    )
-    baker.make("InclusaoAlimentacaoNormal", grupo_inclusao=grupo, data=data)
-    refeicao = baker.make("TipoAlimentacao", nome="Refeição")
-    quantidade = baker.make(
-        "QuantidadePorPeriodo",
-        grupo_inclusao_normal=grupo,
-        numero_alunos=100,
-        periodo_escolar=baker.make("PeriodoEscolar"),
-    )
-    quantidade.tipos_alimentacao.set([refeicao])
-    assert (
-        existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(
-            escola, data, GrupoInclusaoAlimentacaoNormal
-        )
-        is False
-    )
 
 
 def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_com_dia_letivo(escola):
@@ -456,7 +408,7 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_sabado_com_dia_letivo_sig
 
 def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_sabado_com_inclusao(escola):
     data = datetime.date(2024, 4, 13)  # sábado
-    _make_inclusao_normal_autorizada_com_refeicao_e_lanche(escola, data)
+    _make_inclusao_normal_autorizada(escola, data, {"MANHA": ["Refeição", "Lanche"]})
     assert (
         valida_dia_letivo_ou_inclusao_alimentacao_rpl(
             escola, data, GrupoInclusaoAlimentacaoNormal
@@ -467,7 +419,7 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_sabado_com_inclusao(escol
 
 def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_com_inclusao(escola):
     data = datetime.date(2024, 4, 10)
-    _make_inclusao_normal_autorizada_com_refeicao_e_lanche(escola, data)
+    _make_inclusao_normal_autorizada(escola, data, {"MANHA": ["Refeição", "Lanche"]})
     assert (
         valida_dia_letivo_ou_inclusao_alimentacao_rpl(
             escola, data, GrupoInclusaoAlimentacaoNormal
@@ -478,10 +430,13 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_com_inclusao(escola):
 
 def test_valida_rpl_inclusao_periodo_contido(escola):
     data = datetime.date(2024, 4, 10)
-    _make_inclusao_normal_autorizada_periodos(escola, data, ["MANHA"])
+    _make_inclusao_normal_autorizada(escola, data, {"MANHA": ["Refeição", "Lanche"]})
     assert (
         valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-            escola, data, GrupoInclusaoAlimentacaoNormal, ["MANHA"]
+            escola,
+            data,
+            GrupoInclusaoAlimentacaoNormal,
+            [{"periodo": "MANHA", "lanches": ["Lanche"]}],
         )
         is True
     )
@@ -489,37 +444,104 @@ def test_valida_rpl_inclusao_periodo_contido(escola):
 
 def test_valida_rpl_inclusao_periodo_nao_contido(escola):
     data = datetime.date(2024, 4, 10)
-    _make_inclusao_normal_autorizada_periodos(escola, data, ["MANHA"])
+    _make_inclusao_normal_autorizada(escola, data, {"MANHA": ["Refeição", "Lanche"]})
     with pytest.raises(
         ValidationError,
         match="somente nos períodos MANHA",
     ):
         valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-            escola, data, GrupoInclusaoAlimentacaoNormal, ["TARDE"]
+            escola,
+            data,
+            GrupoInclusaoAlimentacaoNormal,
+            [{"periodo": "TARDE", "lanches": ["Lanche"]}],
         )
 
 
 def test_valida_rpl_inclusao_um_periodo_nao_contido_entre_varios(escola):
     data = datetime.date(2024, 4, 10)
-    _make_inclusao_normal_autorizada_periodos(escola, data, ["MANHA", "TARDE"])
+    _make_inclusao_normal_autorizada(
+        escola,
+        data,
+        {"MANHA": ["Refeição", "Lanche"], "TARDE": ["Refeição", "Lanche"]},
+    )
     with pytest.raises(
         ValidationError,
         match="somente nos períodos MANHA e TARDE",
     ):
         valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-            escola, data, GrupoInclusaoAlimentacaoNormal, ["MANHA", "INTEGRAL"]
+            escola,
+            data,
+            GrupoInclusaoAlimentacaoNormal,
+            [
+                {"periodo": "MANHA", "lanches": ["Lanche"]},
+                {"periodo": "INTEGRAL", "lanches": ["Lanche"]},
+            ],
         )
 
 
 def test_valida_rpl_inclusao_todos_periodos_contidos(escola):
     data = datetime.date(2024, 4, 10)
-    _make_inclusao_normal_autorizada_periodos(escola, data, ["MANHA", "TARDE"])
+    _make_inclusao_normal_autorizada(
+        escola,
+        data,
+        {"MANHA": ["Refeição", "Lanche"], "TARDE": ["Refeição", "Lanche"]},
+    )
     assert (
         valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-            escola, data, GrupoInclusaoAlimentacaoNormal, ["MANHA", "TARDE"]
+            escola,
+            data,
+            GrupoInclusaoAlimentacaoNormal,
+            [
+                {"periodo": "MANHA", "lanches": ["Lanche"]},
+                {"periodo": "TARDE", "lanches": ["Lanche"]},
+            ],
         )
         is True
     )
+
+
+def test_valida_rpl_inclusao_sem_refeicao_e_lanche(escola):
+    data = datetime.date(2024, 4, 10)
+    _make_inclusao_normal_autorizada(escola, data, {"MANHA": ["Refeição"]})
+    with pytest.raises(
+        ValidationError,
+        match="não possui Refeição e Lanche autorizado para o periodo MANHA",
+    ):
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola,
+            data,
+            GrupoInclusaoAlimentacaoNormal,
+            [{"periodo": "MANHA", "lanches": ["Lanche"]}],
+        )
+
+
+def test_valida_rpl_inclusao_com_lanche_4h(escola):
+    data = datetime.date(2024, 4, 10)
+    _make_inclusao_normal_autorizada(escola, data, {"MANHA": ["Refeição", "Lanche 4h"]})
+    assert (
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola,
+            data,
+            GrupoInclusaoAlimentacaoNormal,
+            [{"periodo": "MANHA", "lanches": ["Lanche 4h"]}],
+        )
+        is True
+    )
+
+
+def test_valida_rpl_inclusao_lanche_4h_nao_autorizado(escola):
+    data = datetime.date(2024, 4, 10)
+    _make_inclusao_normal_autorizada(escola, data, {"MANHA": ["Refeição", "Lanche"]})
+    with pytest.raises(
+        ValidationError,
+        match="não possui Refeição e Lanche 4h autorizado para o periodo MANHA",
+    ):
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola,
+            data,
+            GrupoInclusaoAlimentacaoNormal,
+            [{"periodo": "MANHA", "lanches": ["Lanche 4h"]}],
+        )
 
 
 def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_sem_nada(escola):
@@ -544,9 +566,21 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_inclusao_cei(escola):
     refeicao = baker.make("TipoAlimentacao", nome="Refeição")
     lanche = baker.make("TipoAlimentacao", nome="Lanche")
     inclusao.tipos_alimentacao.set([refeicao, lanche])
+    faixa = baker.make("FaixaEtaria")
+    periodo_externo = baker.make("PeriodoEscolar", nome="MANHA")
+    baker.make(
+        "QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoDaCEI",
+        inclusao_alimentacao_da_cei=inclusao,
+        faixa_etaria=faixa,
+        quantidade_alunos=10,
+        periodo_externo=periodo_externo,
+    )
     assert (
         valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-            escola, data, InclusaoAlimentacaoDaCEI
+            escola,
+            data,
+            InclusaoAlimentacaoDaCEI,
+            [{"periodo": "MANHA", "lanches": ["Lanche"]}],
         )
         is True
     )
@@ -566,16 +600,20 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_inclusao_cemei(escola):
     )
     refeicao = baker.make("TipoAlimentacao", nome="Refeição")
     lanche = baker.make("TipoAlimentacao", nome="Lanche")
+    periodo = baker.make("PeriodoEscolar", nome="MANHA")
     quantidade = baker.make(
         "QuantidadeDeAlunosEMEIInclusaoDeAlimentacaoCEMEI",
         inclusao_alimentacao_cemei=inclusao,
         quantidade_alunos=10,
-        periodo_escolar=baker.make("PeriodoEscolar"),
+        periodo_escolar=periodo,
     )
     quantidade.tipos_alimentacao.set([refeicao, lanche])
     assert (
         valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-            escola, data, InclusaoDeAlimentacaoCEMEI
+            escola,
+            data,
+            InclusaoDeAlimentacaoCEMEI,
+            [{"periodo": "MANHA", "lanches": ["Lanche"]}],
         )
         is True
     )

--- a/src/dados_comuns/__tests__/test_validators.py
+++ b/src/dados_comuns/__tests__/test_validators.py
@@ -8,6 +8,12 @@ from rest_framework.exceptions import ValidationError
 
 from ...cardapio.alteracao_tipo_alimentacao.models import AlteracaoCardapio
 from ...cardapio.alteracao_tipo_alimentacao_cei.models import AlteracaoCardapioCEI
+from ...escola.dias_letivos.models import DiaLetivoSIGPAE
+from ...inclusao_alimentacao.models import (
+    GrupoInclusaoAlimentacaoNormal,
+    InclusaoAlimentacaoDaCEI,
+    InclusaoDeAlimentacaoCEMEI,
+)
 from ..validators import (
     campo_deve_ser_deste_tipo,
     campo_nao_pode_ser_nulo,
@@ -17,9 +23,13 @@ from ..validators import (
     deve_ser_no_passado,
     deve_ter_extensao_xls_xlsx_pdf,
     dia_util,
+    escola_tem_dia_letivo_no_calendario,
+    existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche,
     nao_pode_ser_feriado,
     nao_pode_ser_no_passado,
     objeto_nao_deve_ter_duplicidade,
+    unidade_tem_dia_letivo_sigpae,
+    valida_dia_letivo_ou_inclusao_alimentacao_rpl,
     valida_duplicidade_solicitacoes,
     valida_duplicidade_solicitacoes_cei,
     verificar_se_existe,
@@ -258,3 +268,248 @@ def test_valida_duplicidade_solicitacoes_duplicada_cei(
         match="Já existe uma solicitação de RPL para o mês e período selecionado!",
     ):
         valida_duplicidade_solicitacoes_cei(solicitacao_substituicao_cardapio_cei, data)
+
+
+def _make_inclusao_normal_autorizada_com_refeicao_e_lanche(escola, data):
+    grupo = baker.make(
+        "GrupoInclusaoAlimentacaoNormal",
+        escola=escola,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make("InclusaoAlimentacaoNormal", grupo_inclusao=grupo, data=data)
+    refeicao = baker.make("TipoAlimentacao", nome="Refeição")
+    lanche = baker.make("TipoAlimentacao", nome="Lanche")
+    quantidade = baker.make(
+        "QuantidadePorPeriodo",
+        grupo_inclusao_normal=grupo,
+        numero_alunos=100,
+        periodo_escolar=baker.make("PeriodoEscolar"),
+    )
+    quantidade.tipos_alimentacao.set([refeicao, lanche])
+    return grupo
+
+
+def test_unidade_tem_dia_letivo_sigpae_escola_dentro(escola):
+    data = datetime.date(2024, 4, 10)
+    dia_letivo = baker.make(DiaLetivoSIGPAE, data=data)
+    dia_letivo.escolas.add(escola)
+    assert unidade_tem_dia_letivo_sigpae(escola, data) is True
+
+
+def test_escola_tem_dia_letivo_no_calendario_true(escola):
+    data = datetime.date(2024, 4, 10)
+    baker.make("DiaCalendario", escola=escola, data=data, dia_letivo=True)
+    assert escola_tem_dia_letivo_no_calendario(escola, data) is True
+
+
+def test_escola_tem_dia_letivo_no_calendario_false(escola):
+    data = datetime.date(2024, 4, 10)
+    baker.make("DiaCalendario", escola=escola, data=data, dia_letivo=False)
+    assert escola_tem_dia_letivo_no_calendario(escola, data) is False
+
+
+def test_escola_tem_dia_letivo_no_calendario_sem_registro(escola):
+    data = datetime.date(2024, 4, 10)
+    assert escola_tem_dia_letivo_no_calendario(escola, data) is False
+
+
+def test_unidade_tem_dia_letivo_sigpae_lote_e_tipo_unidade(escola):
+    data = datetime.date(2024, 4, 10)
+    dia_letivo = baker.make(DiaLetivoSIGPAE, data=data)
+    dia_letivo.lotes.add(escola.lote)
+    dia_letivo.tipos_unidade_escolar.add(escola.tipo_unidade)
+    assert unidade_tem_dia_letivo_sigpae(escola, data) is True
+
+
+def test_unidade_tem_dia_letivo_sigpae_sem_registro(escola):
+    data = datetime.date(2024, 4, 10)
+    assert unidade_tem_dia_letivo_sigpae(escola, data) is False
+
+
+def test_unidade_tem_dia_letivo_sigpae_outra_escola(escola):
+    data = datetime.date(2024, 4, 10)
+    outra_escola = baker.make("Escola")
+    dia_letivo = baker.make(DiaLetivoSIGPAE, data=data)
+    dia_letivo.escolas.add(outra_escola)
+    assert unidade_tem_dia_letivo_sigpae(escola, data) is False
+
+
+def test_existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(escola):
+    data = datetime.date(2024, 4, 10)
+    _make_inclusao_normal_autorizada_com_refeicao_e_lanche(escola, data)
+    assert (
+        existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(
+            escola, data, GrupoInclusaoAlimentacaoNormal
+        )
+        is True
+    )
+
+
+def test_existe_inclusao_alimentacao_autorizada_sem_lanche(escola):
+    data = datetime.date(2024, 4, 10)
+    grupo = baker.make(
+        "GrupoInclusaoAlimentacaoNormal",
+        escola=escola,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make("InclusaoAlimentacaoNormal", grupo_inclusao=grupo, data=data)
+    refeicao = baker.make("TipoAlimentacao", nome="Refeição")
+    quantidade = baker.make(
+        "QuantidadePorPeriodo",
+        grupo_inclusao_normal=grupo,
+        numero_alunos=100,
+        periodo_escolar=baker.make("PeriodoEscolar"),
+    )
+    quantidade.tipos_alimentacao.set([refeicao])
+    assert (
+        existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(
+            escola, data, GrupoInclusaoAlimentacaoNormal
+        )
+        is False
+    )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_com_dia_letivo(escola):
+    data = datetime.date(2024, 4, 10)
+    dia_letivo = baker.make(DiaLetivoSIGPAE, data=data)
+    dia_letivo.escolas.add(escola)
+    assert (
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal
+        )
+        is True
+    )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_com_dia_calendario(escola):
+    data = datetime.date(2024, 4, 10)
+    baker.make("DiaCalendario", escola=escola, data=data, dia_letivo=True)
+    assert (
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal
+        )
+        is True
+    )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_dia_calendario_nao_letivo(
+    escola,
+):
+    data = datetime.date(2024, 4, 10)
+    baker.make("DiaCalendario", escola=escola, data=data, dia_letivo=False)
+    with pytest.raises(
+        ValidationError,
+        match="Dia 10/04 não é um dia letivo ou não existe uma inclusão",
+    ):
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal
+        )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_sabado_ignora_dia_calendario(
+    escola,
+):
+    data = datetime.date(2024, 4, 13)  # sábado
+    baker.make("DiaCalendario", escola=escola, data=data, dia_letivo=True)
+    with pytest.raises(
+        ValidationError,
+        match="Dia 13/04 não é um dia letivo ou não existe uma inclusão",
+    ):
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal
+        )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_sabado_com_dia_letivo_sigpae(
+    escola,
+):
+    data = datetime.date(2024, 4, 13)  # sábado
+    dia_letivo = baker.make(DiaLetivoSIGPAE, data=data)
+    dia_letivo.escolas.add(escola)
+    assert (
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal
+        )
+        is True
+    )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_sabado_com_inclusao(escola):
+    data = datetime.date(2024, 4, 13)  # sábado
+    _make_inclusao_normal_autorizada_com_refeicao_e_lanche(escola, data)
+    assert (
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal
+        )
+        is True
+    )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_com_inclusao(escola):
+    data = datetime.date(2024, 4, 10)
+    _make_inclusao_normal_autorizada_com_refeicao_e_lanche(escola, data)
+    assert (
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal
+        )
+        is True
+    )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_sem_nada(escola):
+    data = datetime.date(2024, 4, 10)
+    with pytest.raises(
+        ValidationError,
+        match="Dia 10/04 não é um dia letivo ou não existe uma inclusão",
+    ):
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, GrupoInclusaoAlimentacaoNormal
+        )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_inclusao_cei(escola):
+    data = datetime.date(2024, 4, 10)
+    inclusao = baker.make(
+        "InclusaoAlimentacaoDaCEI",
+        escola=escola,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make("DiasMotivosInclusaoDeAlimentacaoCEI", inclusao_cei=inclusao, data=data)
+    refeicao = baker.make("TipoAlimentacao", nome="Refeição")
+    lanche = baker.make("TipoAlimentacao", nome="Lanche")
+    inclusao.tipos_alimentacao.set([refeicao, lanche])
+    assert (
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, InclusaoAlimentacaoDaCEI
+        )
+        is True
+    )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_inclusao_cemei(escola):
+    data = datetime.date(2024, 4, 10)
+    inclusao = baker.make(
+        "InclusaoDeAlimentacaoCEMEI",
+        escola=escola,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "DiasMotivosInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        data=data,
+    )
+    refeicao = baker.make("TipoAlimentacao", nome="Refeição")
+    lanche = baker.make("TipoAlimentacao", nome="Lanche")
+    quantidade = baker.make(
+        "QuantidadeDeAlunosEMEIInclusaoDeAlimentacaoCEMEI",
+        inclusao_alimentacao_cemei=inclusao,
+        quantidade_alunos=10,
+        periodo_escolar=baker.make("PeriodoEscolar"),
+    )
+    quantidade.tipos_alimentacao.set([refeicao, lanche])
+    assert (
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, InclusaoDeAlimentacaoCEMEI
+        )
+        is True
+    )

--- a/src/dados_comuns/__tests__/test_validators.py
+++ b/src/dados_comuns/__tests__/test_validators.py
@@ -563,27 +563,23 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_inclusao_cei(escola):
         status="CODAE_AUTORIZADO",
     )
     baker.make("DiasMotivosInclusaoDeAlimentacaoCEI", inclusao_cei=inclusao, data=data)
-    refeicao = baker.make("TipoAlimentacao", nome="Refeição")
-    lanche = baker.make("TipoAlimentacao", nome="Lanche")
-    inclusao.tipos_alimentacao.set([refeicao, lanche])
-    faixa = baker.make("FaixaEtaria")
-    periodo_externo = baker.make("PeriodoEscolar", nome="MANHA")
-    baker.make(
-        "QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoDaCEI",
-        inclusao_alimentacao_da_cei=inclusao,
-        faixa_etaria=faixa,
-        quantidade_alunos=10,
-        periodo_externo=periodo_externo,
-    )
     assert (
         valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-            escola,
-            data,
-            InclusaoAlimentacaoDaCEI,
-            [{"periodo": "MANHA", "lanches": ["Lanche"]}],
+            escola, data, InclusaoAlimentacaoDaCEI
         )
         is True
     )
+
+
+def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_cei_sem_inclusao(escola):
+    data = datetime.date(2024, 4, 10)
+    with pytest.raises(
+        ValidationError,
+        match="Dia 10/04 não é um dia letivo ou não existe uma inclusão",
+    ):
+        valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+            escola, data, InclusaoAlimentacaoDaCEI
+        )
 
 
 def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_inclusao_cemei(escola):

--- a/src/dados_comuns/__tests__/test_validators.py
+++ b/src/dados_comuns/__tests__/test_validators.py
@@ -628,7 +628,7 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_cemei_parte_cei(escola):
         inclusao_alimentacao_cemei=inclusao,
         data=data,
     )
-    faixa = baker.make("FaixaEtaria")
+    faixa = baker.make("FaixaEtaria", inicio=0, fim=12, ativo=True)
     periodo = baker.make("PeriodoEscolar", nome="MANHA")
     baker.make(
         "QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI",
@@ -657,7 +657,7 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_cemei_parte_errada(escola
         inclusao_alimentacao_cemei=inclusao,
         data=data,
     )
-    faixa = baker.make("FaixaEtaria")
+    faixa = baker.make("FaixaEtaria", inicio=0, fim=12, ativo=True)
     periodo = baker.make("PeriodoEscolar", nome="MANHA")
     baker.make(
         "QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI",
@@ -687,7 +687,7 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_cemei_todos_sem_emei(esco
         inclusao_alimentacao_cemei=inclusao,
         data=data,
     )
-    faixa = baker.make("FaixaEtaria")
+    faixa = baker.make("FaixaEtaria", inicio=0, fim=12, ativo=True)
     periodo = baker.make("PeriodoEscolar", nome="MANHA")
     baker.make(
         "QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI",
@@ -717,7 +717,7 @@ def test_valida_dia_letivo_ou_inclusao_alimentacao_rpl_cemei_escopo_nulo(escola)
         inclusao_alimentacao_cemei=inclusao,
         data=data,
     )
-    faixa = baker.make("FaixaEtaria")
+    faixa = baker.make("FaixaEtaria", inicio=0, fim=12, ativo=True)
     periodo = baker.make("PeriodoEscolar", nome="MANHA")
     baker.make(
         "QuantidadeDeAlunosPorFaixaEtariaDaInclusaoDeAlimentacaoCEMEI",

--- a/src/dados_comuns/validators.py
+++ b/src/dados_comuns/validators.py
@@ -438,8 +438,89 @@ def _valida_inclusao_alimentacao_cei_rpl(escola, data, modelo):
     )
 
 
+def _partes_inclusao_cemei_autorizadas(escola, data, modelo):
+    """Retorna as partes (CEI/EMEI) cobertas pela inclusão CEMEI autorizada.
+
+    Args:
+        escola (Escola): Unidade educacional que está fazendo a solicitação.
+        data (datetime.date): Data informada na solicitação.
+        modelo (Model): Modelo de inclusão de alimentação a ser consultado.
+
+    Returns:
+        set[str]: Conjunto com as partes cobertas, podendo conter ``"CEI"`` e
+        ``"EMEI"``.
+    """
+    inclusoes = _inclusoes_alimentacao_autorizadas_base(escola, data, modelo)
+    partes = set()
+    if inclusoes.filter(quantidade_alunos_cei_da_inclusao_cemei__isnull=False).exists():
+        partes.add("CEI")
+    if inclusoes.filter(
+        quantidade_alunos_emei_da_inclusao_cemei__isnull=False
+    ).exists():
+        partes.add("EMEI")
+    return partes
+
+
+def _valida_parte_cemei_autorizada(data, parte, partes_autorizadas):
+    """Valida se a parte solicitada está coberta pela inclusão CEMEI.
+
+    Args:
+        data (datetime.date): Data informada na solicitação.
+        parte (str): Parte solicitada (``"CEI"`` ou ``"EMEI"``).
+        partes_autorizadas (set[str]): Partes cobertas pela inclusão.
+
+    Raises:
+        serializers.ValidationError: Quando a parte solicitada não está coberta.
+    """
+    if parte not in partes_autorizadas:
+        raise serializers.ValidationError(
+            f"Inclusão autorizada para o dia {data.strftime('%d/%m')} somente nos "
+            f"para {_formata_periodos_para_mensagem(partes_autorizadas)}"
+        )
+
+
+def _valida_inclusao_alimentacao_cemei_rpl(
+    escola, data, modelo, alunos_cei_e_ou_emei, periodos_lanches_emei
+):
+    """Valida a solicitação RPL de CEMEI contra a inclusão de alimentação.
+
+    Para a parte CEI, basta existir a inclusão; para a parte EMEI, valida
+    Refeição e o lanche solicitado por período, como em EMEI/EMEF.
+
+    Args:
+        escola (Escola): Unidade educacional que está fazendo a solicitação.
+        data (datetime.date): Data informada na solicitação.
+        modelo (Model): Modelo de inclusão de alimentação a ser consultado.
+        alunos_cei_e_ou_emei (str): Escopo da solicitação (``"CEI"``, ``"EMEI"``
+            ou ``"TODOS"``).
+        periodos_lanches_emei (Iterable[dict]): Períodos e lanches das
+            substituições EMEI da solicitação.
+
+    Returns:
+        bool: ``True`` quando a inclusão autorizada atende a solicitação.
+
+    Raises:
+        serializers.ValidationError: Quando não há inclusão, quando a parte
+        solicitada não está coberta ou quando a parte EMEI não possui Refeição e
+        o lanche solicitado.
+    """
+    partes_autorizadas = _partes_inclusao_cemei_autorizadas(escola, data, modelo)
+    if not partes_autorizadas:
+        raise serializers.ValidationError(
+            f'Dia {data.strftime("%d/%m")} não é um dia letivo ou não existe uma '
+            "inclusão de alimentação para a data"
+        )
+    if alunos_cei_e_ou_emei in ("CEI", "TODOS"):
+        _valida_parte_cemei_autorizada(data, "CEI", partes_autorizadas)
+    if alunos_cei_e_ou_emei in ("EMEI", "TODOS"):
+        _valida_parte_cemei_autorizada(data, "EMEI", partes_autorizadas)
+    if alunos_cei_e_ou_emei in ("EMEI", "TODOS"):
+        _valida_inclusao_alimentacao_rpl(escola, data, modelo, periodos_lanches_emei)
+    return True
+
+
 def valida_dia_letivo_ou_inclusao_alimentacao_rpl(
-    escola, data, modelo, periodos_lanches=None
+    escola, data, modelo, periodos_lanches=None, alunos_cei_e_ou_emei=None
 ):
     """Valida a data de uma solicitação RPL para a unidade educacional.
 
@@ -462,7 +543,9 @@ def valida_dia_letivo_ou_inclusao_alimentacao_rpl(
         periodos_lanches (Iterable[dict], optional): Itens no formato
             ``{"periodo": str, "lanches": list[str]}``, representando os
             períodos da solicitação RPL e os tipos de lanche substituídos em
-            cada período.
+            cada período. Para CEMEI, contém somente as substituições EMEI.
+        alunos_cei_e_ou_emei (str, optional): Escopo da solicitação CEMEI
+            (``"CEI"``, ``"EMEI"`` ou ``"TODOS"``).
 
     Returns:
         bool: ``True`` quando a data é válida para a solicitação RPL.
@@ -473,7 +556,10 @@ def valida_dia_letivo_ou_inclusao_alimentacao_rpl(
         está autorizado na inclusão ou quando a inclusão não possui Refeição e o
         lanche solicitado para o período.
     """
-    from ..inclusao_alimentacao.models import InclusaoAlimentacaoDaCEI
+    from ..inclusao_alimentacao.models import (
+        InclusaoAlimentacaoDaCEI,
+        InclusaoDeAlimentacaoCEMEI,
+    )
 
     if not eh_fim_de_semana(data) and escola_tem_dia_letivo_no_calendario(escola, data):
         return True
@@ -481,6 +567,10 @@ def valida_dia_letivo_ou_inclusao_alimentacao_rpl(
         return True
     if modelo is InclusaoAlimentacaoDaCEI:
         return _valida_inclusao_alimentacao_cei_rpl(escola, data, modelo)
+    if modelo is InclusaoDeAlimentacaoCEMEI:
+        return _valida_inclusao_alimentacao_cemei_rpl(
+            escola, data, modelo, alunos_cei_e_ou_emei, periodos_lanches
+        )
     return _valida_inclusao_alimentacao_rpl(escola, data, modelo, periodos_lanches)
 
 

--- a/src/dados_comuns/validators.py
+++ b/src/dados_comuns/validators.py
@@ -198,6 +198,60 @@ def unidade_tem_dia_letivo_sigpae(escola, data):
     ).exists()
 
 
+def _inclusoes_alimentacao_autorizadas(escola, data, modelo):
+    """Retorna as Inclusões de Alimentação autorizadas (não contínuas) na data.
+
+    Considera apenas inclusões que tenham, simultaneamente, os tipos de
+    alimentação Refeição e Lanche.
+
+    Args:
+        escola (Escola): Unidade educacional que está fazendo a solicitação.
+        data (datetime.date): Data informada na solicitação.
+        modelo (Model): Modelo de inclusão de alimentação a ser consultado. Pode
+            ser ``GrupoInclusaoAlimentacaoNormal``,
+            ``InclusaoAlimentacaoDaCEI`` ou ``InclusaoDeAlimentacaoCEMEI``.
+
+    Returns:
+        QuerySet: Queryset das inclusões autorizadas com refeição e lanche.
+    """
+    from ..inclusao_alimentacao.models import (
+        GrupoInclusaoAlimentacaoNormal,
+        InclusaoAlimentacaoDaCEI,
+        InclusaoDeAlimentacaoCEMEI,
+    )
+
+    if modelo is GrupoInclusaoAlimentacaoNormal:
+        return modelo.objects.filter(
+            escola=escola,
+            status="CODAE_AUTORIZADO",
+            inclusoes_normais__data=data,
+            inclusoes_normais__cancelado=False,
+            quantidades_por_periodo__tipos_alimentacao__nome="Refeição",
+        ).filter(quantidades_por_periodo__tipos_alimentacao__nome="Lanche")
+
+    if modelo is InclusaoAlimentacaoDaCEI:
+        return modelo.objects.filter(
+            escola=escola,
+            status="CODAE_AUTORIZADO",
+            dias_motivos_da_inclusao_cei__data=data,
+            dias_motivos_da_inclusao_cei__cancelado=False,
+            tipos_alimentacao__nome="Refeição",
+        ).filter(tipos_alimentacao__nome="Lanche")
+
+    if modelo is InclusaoDeAlimentacaoCEMEI:
+        return modelo.objects.filter(
+            escola=escola,
+            status="CODAE_AUTORIZADO",
+            dias_motivos_da_inclusao_cemei__data=data,
+            dias_motivos_da_inclusao_cemei__cancelado=False,
+            quantidade_alunos_emei_da_inclusao_cemei__tipos_alimentacao__nome="Refeição",
+        ).filter(
+            quantidade_alunos_emei_da_inclusao_cemei__tipos_alimentacao__nome="Lanche"
+        )
+
+    return modelo.objects.none()
+
+
 def existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(escola, data, modelo):
     """Verifica se existe uma Inclusão de Alimentação autorizada na data.
 
@@ -215,57 +269,74 @@ def existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(escola, data, m
         bool: ``True`` quando existe inclusão autorizada com refeição e lanche
         para a data informada.
     """
+    return _inclusoes_alimentacao_autorizadas(escola, data, modelo).exists()
+
+
+def _periodos_autorizados_inclusao(escola, data, modelo):
+    """Retorna os nomes dos períodos escolares autorizados na inclusão.
+
+    Args:
+        escola (Escola): Unidade educacional que está fazendo a solicitação.
+        data (datetime.date): Data informada na solicitação.
+        modelo (Model): Modelo de inclusão de alimentação a ser consultado.
+
+    Returns:
+        set[str]: Conjunto com os nomes dos períodos escolares autorizados.
+    """
     from ..inclusao_alimentacao.models import (
         GrupoInclusaoAlimentacaoNormal,
         InclusaoAlimentacaoDaCEI,
         InclusaoDeAlimentacaoCEMEI,
     )
 
+    inclusoes = _inclusoes_alimentacao_autorizadas(escola, data, modelo)
+
     if modelo is GrupoInclusaoAlimentacaoNormal:
-        return (
-            modelo.objects.filter(
-                escola=escola,
-                status="CODAE_AUTORIZADO",
-                inclusoes_normais__data=data,
-                inclusoes_normais__cancelado=False,
-                quantidades_por_periodo__tipos_alimentacao__nome="Refeição",
-            )
-            .filter(quantidades_por_periodo__tipos_alimentacao__nome="Lanche")
-            .exists()
+        return set(
+            inclusoes.values_list(
+                "quantidades_por_periodo__periodo_escolar__nome", flat=True
+            ).distinct()
         )
 
     if modelo is InclusaoAlimentacaoDaCEI:
-        return (
-            modelo.objects.filter(
-                escola=escola,
-                status="CODAE_AUTORIZADO",
-                dias_motivos_da_inclusao_cei__data=data,
-                dias_motivos_da_inclusao_cei__cancelado=False,
-                tipos_alimentacao__nome="Refeição",
-            )
-            .filter(tipos_alimentacao__nome="Lanche")
-            .exists()
+        return set(
+            inclusoes.values_list(
+                "quantidade_alunos_da_inclusao__periodo_externo__nome", flat=True
+            ).distinct()
         )
 
     if modelo is InclusaoDeAlimentacaoCEMEI:
-        return (
-            modelo.objects.filter(
-                escola=escola,
-                status="CODAE_AUTORIZADO",
-                dias_motivos_da_inclusao_cemei__data=data,
-                dias_motivos_da_inclusao_cemei__cancelado=False,
-                quantidade_alunos_emei_da_inclusao_cemei__tipos_alimentacao__nome="Refeição",
-            )
-            .filter(
-                quantidade_alunos_emei_da_inclusao_cemei__tipos_alimentacao__nome="Lanche"
-            )
-            .exists()
-        )
+        periodos_cei = inclusoes.values_list(
+            "quantidade_alunos_cei_da_inclusao_cemei__periodo_escolar__nome",
+            flat=True,
+        ).distinct()
+        periodos_emei = inclusoes.values_list(
+            "quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__nome",
+            flat=True,
+        ).distinct()
+        return set(periodos_cei) | set(periodos_emei)
 
-    return False
+    return set()
 
 
-def valida_dia_letivo_ou_inclusao_alimentacao_rpl(escola, data, modelo):
+def _formata_periodos_para_mensagem(periodos):
+    """Formata uma coleção de nomes de períodos para exibição em mensagem.
+
+    Args:
+        periodos (Iterable[str]): Nomes dos períodos escolares.
+
+    Returns:
+        str: Nomes ordenados separados por vírgula e ``" e "`` antes do último.
+    """
+    periodos = sorted(p for p in periodos if p)
+    if not periodos:
+        return ""
+    if len(periodos) == 1:
+        return periodos[0]
+    return ", ".join(periodos[:-1]) + " e " + periodos[-1]
+
+
+def valida_dia_letivo_ou_inclusao_alimentacao_rpl(escola, data, modelo, periodos=None):
     """Valida a data de uma solicitação RPL para a unidade educacional.
 
     Permite o envio quando:
@@ -273,7 +344,8 @@ def valida_dia_letivo_ou_inclusao_alimentacao_rpl(escola, data, modelo):
           ``dia_letivo=True`` para a data; OU
         - a unidade possui DiaLetivoSIGPAE para a data; OU
         - existe uma Inclusão de Alimentação autorizada (não contínua) para a
-          mesma data com refeição e lanche.
+          mesma data com refeição e lanche, e os períodos escolares da
+          solicitação estão contidos nos períodos autorizados da inclusão.
 
     A verificação de ``DiaCalendario`` é aplicada somente de segunda a sexta.
     Aos sábados e domingos, valem sempre as regras de DiaLetivoSIGPAE ou de
@@ -285,21 +357,32 @@ def valida_dia_letivo_ou_inclusao_alimentacao_rpl(escola, data, modelo):
         escola (Escola): Unidade educacional que está fazendo a solicitação.
         data (datetime.date): Data informada na solicitação.
         modelo (Model): Modelo de inclusão de alimentação a ser consultado.
+        periodos (Iterable[str], optional): Nomes dos períodos escolares da
+            solicitação RPL. Quando informado, valida se estão contidos nos
+            períodos autorizados da inclusão.
 
     Returns:
         bool: ``True`` quando a data é válida para a solicitação RPL.
 
     Raises:
         serializers.ValidationError: Quando a data não é um dia letivo e não
-        existe uma inclusão de alimentação para a data.
+        existe uma inclusão de alimentação para a data, ou quando algum período
+        da solicitação não está autorizado na inclusão.
     """
     if not eh_fim_de_semana(data) and escola_tem_dia_letivo_no_calendario(escola, data):
         return True
     if unidade_tem_dia_letivo_sigpae(escola, data):
         return True
-    if existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(
-        escola, data, modelo
-    ):
+    if _inclusoes_alimentacao_autorizadas(escola, data, modelo).exists():
+        if periodos:
+            periodos_autorizados = _periodos_autorizados_inclusao(escola, data, modelo)
+            periodos_solicitados = {p for p in periodos if p}
+            if not periodos_solicitados.issubset(periodos_autorizados):
+                raise serializers.ValidationError(
+                    f'Para o dia {data.strftime("%d/%m")}, a inclusão está '
+                    "autorizada somente nos períodos "
+                    f"{_formata_periodos_para_mensagem(periodos_autorizados)}."
+                )
         return True
     raise serializers.ValidationError(
         f'Dia {data.strftime("%d/%m")} não é um dia letivo ou não existe uma '

--- a/src/dados_comuns/validators.py
+++ b/src/dados_comuns/validators.py
@@ -474,8 +474,8 @@ def _valida_parte_cemei_autorizada(data, parte, partes_autorizadas):
     """
     if parte not in partes_autorizadas:
         raise serializers.ValidationError(
-            f"Inclusão autorizada para o dia {data.strftime('%d/%m')} somente nos "
-            f"para {_formata_periodos_para_mensagem(partes_autorizadas)}"
+            f"Inclusão autorizada para o dia {data.strftime('%d/%m')} somente para "
+            f"{_formata_periodos_para_mensagem(partes_autorizadas)}"
         )
 
 
@@ -491,8 +491,8 @@ def _valida_inclusao_alimentacao_cemei_rpl(
         escola (Escola): Unidade educacional que está fazendo a solicitação.
         data (datetime.date): Data informada na solicitação.
         modelo (Model): Modelo de inclusão de alimentação a ser consultado.
-        alunos_cei_e_ou_emei (str): Escopo da solicitação (``"CEI"``, ``"EMEI"``
-            ou ``"TODOS"``).
+        alunos_cei_e_ou_emei (str, optional): Escopo da solicitação (``"CEI"``,
+            ``"EMEI"`` ou ``"TODOS"``). Quando nulo, considera ``"TODOS"``.
         periodos_lanches_emei (Iterable[dict]): Períodos e lanches das
             substituições EMEI da solicitação.
 
@@ -510,6 +510,7 @@ def _valida_inclusao_alimentacao_cemei_rpl(
             f'Dia {data.strftime("%d/%m")} não é um dia letivo ou não existe uma '
             "inclusão de alimentação para a data"
         )
+    alunos_cei_e_ou_emei = alunos_cei_e_ou_emei or "TODOS"
     if alunos_cei_e_ou_emei in ("CEI", "TODOS"):
         _valida_parte_cemei_autorizada(data, "CEI", partes_autorizadas)
     if alunos_cei_e_ou_emei in ("EMEI", "TODOS"):

--- a/src/dados_comuns/validators.py
+++ b/src/dados_comuns/validators.py
@@ -198,11 +198,8 @@ def unidade_tem_dia_letivo_sigpae(escola, data):
     ).exists()
 
 
-def _inclusoes_alimentacao_autorizadas(escola, data, modelo):
+def _inclusoes_alimentacao_autorizadas_base(escola, data, modelo):
     """Retorna as Inclusões de Alimentação autorizadas (não contínuas) na data.
-
-    Considera apenas inclusões que tenham, simultaneamente, os tipos de
-    alimentação Refeição e Lanche.
 
     Args:
         escola (Escola): Unidade educacional que está fazendo a solicitação.
@@ -212,7 +209,7 @@ def _inclusoes_alimentacao_autorizadas(escola, data, modelo):
             ``InclusaoAlimentacaoDaCEI`` ou ``InclusaoDeAlimentacaoCEMEI``.
 
     Returns:
-        QuerySet: Queryset das inclusões autorizadas com refeição e lanche.
+        QuerySet: Queryset das inclusões autorizadas para a data e escola.
     """
     from ..inclusao_alimentacao.models import (
         GrupoInclusaoAlimentacaoNormal,
@@ -226,8 +223,7 @@ def _inclusoes_alimentacao_autorizadas(escola, data, modelo):
             status="CODAE_AUTORIZADO",
             inclusoes_normais__data=data,
             inclusoes_normais__cancelado=False,
-            quantidades_por_periodo__tipos_alimentacao__nome="Refeição",
-        ).filter(quantidades_por_periodo__tipos_alimentacao__nome="Lanche")
+        )
 
     if modelo is InclusaoAlimentacaoDaCEI:
         return modelo.objects.filter(
@@ -235,8 +231,7 @@ def _inclusoes_alimentacao_autorizadas(escola, data, modelo):
             status="CODAE_AUTORIZADO",
             dias_motivos_da_inclusao_cei__data=data,
             dias_motivos_da_inclusao_cei__cancelado=False,
-            tipos_alimentacao__nome="Refeição",
-        ).filter(tipos_alimentacao__nome="Lanche")
+        )
 
     if modelo is InclusaoDeAlimentacaoCEMEI:
         return modelo.objects.filter(
@@ -244,32 +239,9 @@ def _inclusoes_alimentacao_autorizadas(escola, data, modelo):
             status="CODAE_AUTORIZADO",
             dias_motivos_da_inclusao_cemei__data=data,
             dias_motivos_da_inclusao_cemei__cancelado=False,
-            quantidade_alunos_emei_da_inclusao_cemei__tipos_alimentacao__nome="Refeição",
-        ).filter(
-            quantidade_alunos_emei_da_inclusao_cemei__tipos_alimentacao__nome="Lanche"
         )
 
     return modelo.objects.none()
-
-
-def existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(escola, data, modelo):
-    """Verifica se existe uma Inclusão de Alimentação autorizada na data.
-
-    Considera apenas inclusões que não sejam do tipo Inclusão Contínua e que
-    tenham, simultaneamente, os tipos de alimentação Refeição e Lanche.
-
-    Args:
-        escola (Escola): Unidade educacional que está fazendo a solicitação.
-        data (datetime.date): Data informada na solicitação.
-        modelo (Model): Modelo de inclusão de alimentação a ser consultado. Pode
-            ser ``GrupoInclusaoAlimentacaoNormal``,
-            ``InclusaoAlimentacaoDaCEI`` ou ``InclusaoDeAlimentacaoCEMEI``.
-
-    Returns:
-        bool: ``True`` quando existe inclusão autorizada com refeição e lanche
-        para a data informada.
-    """
-    return _inclusoes_alimentacao_autorizadas(escola, data, modelo).exists()
 
 
 def _periodos_autorizados_inclusao(escola, data, modelo):
@@ -289,7 +261,7 @@ def _periodos_autorizados_inclusao(escola, data, modelo):
         InclusaoDeAlimentacaoCEMEI,
     )
 
-    inclusoes = _inclusoes_alimentacao_autorizadas(escola, data, modelo)
+    inclusoes = _inclusoes_alimentacao_autorizadas_base(escola, data, modelo)
 
     if modelo is GrupoInclusaoAlimentacaoNormal:
         return set(
@@ -319,6 +291,66 @@ def _periodos_autorizados_inclusao(escola, data, modelo):
     return set()
 
 
+def _inclusao_tem_refeicao_e_lanche_para_periodo(
+    escola, data, modelo, periodo_nome, lanche_nome
+):
+    """Verifica se a inclusão possui Refeição e o lanche no período.
+
+    Args:
+        escola (Escola): Unidade educacional que está fazendo a solicitação.
+        data (datetime.date): Data informada na solicitação.
+        modelo (Model): Modelo de inclusão de alimentação a ser consultado.
+        periodo_nome (str): Nome do período escolar da solicitação.
+        lanche_nome (str): Nome do tipo de lanche solicitado (``"Lanche"`` ou
+            ``"Lanche 4h"``).
+
+    Returns:
+        bool: ``True`` quando a inclusão autorizada possui Refeição e o lanche
+        informado para o período.
+    """
+    from ..inclusao_alimentacao.models import (
+        GrupoInclusaoAlimentacaoNormal,
+        InclusaoAlimentacaoDaCEI,
+        InclusaoDeAlimentacaoCEMEI,
+    )
+
+    inclusoes = _inclusoes_alimentacao_autorizadas_base(escola, data, modelo)
+
+    if modelo is GrupoInclusaoAlimentacaoNormal:
+        return (
+            inclusoes.filter(
+                quantidades_por_periodo__periodo_escolar__nome=periodo_nome,
+                quantidades_por_periodo__tipos_alimentacao__nome="Refeição",
+            )
+            .filter(quantidades_por_periodo__tipos_alimentacao__nome=lanche_nome)
+            .exists()
+        )
+
+    if modelo is InclusaoAlimentacaoDaCEI:
+        return (
+            inclusoes.filter(
+                quantidade_alunos_da_inclusao__periodo_externo__nome=periodo_nome,
+                tipos_alimentacao__nome="Refeição",
+            )
+            .filter(tipos_alimentacao__nome=lanche_nome)
+            .exists()
+        )
+
+    if modelo is InclusaoDeAlimentacaoCEMEI:
+        return (
+            inclusoes.filter(
+                quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__nome=periodo_nome,
+                quantidade_alunos_emei_da_inclusao_cemei__tipos_alimentacao__nome="Refeição",
+            )
+            .filter(
+                quantidade_alunos_emei_da_inclusao_cemei__tipos_alimentacao__nome=lanche_nome
+            )
+            .exists()
+        )
+
+    return False
+
+
 def _formata_periodos_para_mensagem(periodos):
     """Formata uma coleção de nomes de períodos para exibição em mensagem.
 
@@ -336,7 +368,53 @@ def _formata_periodos_para_mensagem(periodos):
     return ", ".join(periodos[:-1]) + " e " + periodos[-1]
 
 
-def valida_dia_letivo_ou_inclusao_alimentacao_rpl(escola, data, modelo, periodos=None):
+def _valida_inclusao_alimentacao_rpl(escola, data, modelo, periodos_lanches):
+    """Valida a solicitação RPL contra a inclusão de alimentação autorizada.
+
+    Args:
+        escola (Escola): Unidade educacional que está fazendo a solicitação.
+        data (datetime.date): Data informada na solicitação.
+        modelo (Model): Modelo de inclusão de alimentação a ser consultado.
+        periodos_lanches (Iterable[dict]): Períodos e lanches da solicitação RPL.
+
+    Returns:
+        bool: ``True`` quando a inclusão autorizada atende a solicitação.
+
+    Raises:
+        serializers.ValidationError: Quando não há inclusão para a data, quando
+        algum período não está autorizado ou quando a inclusão não possui
+        Refeição e o lanche solicitado para o período.
+    """
+    periodos_autorizados = _periodos_autorizados_inclusao(escola, data, modelo)
+    if not periodos_autorizados:
+        raise serializers.ValidationError(
+            f'Dia {data.strftime("%d/%m")} não é um dia letivo ou não existe uma '
+            "inclusão de alimentação para a data"
+        )
+    for item in periodos_lanches or []:
+        periodo = item.get("periodo")
+        lanches = item.get("lanches") or []
+        if periodo not in periodos_autorizados:
+            raise serializers.ValidationError(
+                f'Para o dia {data.strftime("%d/%m")}, a inclusão está '
+                "autorizada somente nos períodos "
+                f"{_formata_periodos_para_mensagem(periodos_autorizados)}."
+            )
+        for lanche in lanches:
+            if not _inclusao_tem_refeicao_e_lanche_para_periodo(
+                escola, data, modelo, periodo, lanche
+            ):
+                raise serializers.ValidationError(
+                    f'Para o dia {data.strftime("%d/%m")}, a inclusão autorizada '
+                    f"não possui Refeição e {lanche} autorizado para o periodo "
+                    f"{periodo}."
+                )
+    return True
+
+
+def valida_dia_letivo_ou_inclusao_alimentacao_rpl(
+    escola, data, modelo, periodos_lanches=None
+):
     """Valida a data de uma solicitação RPL para a unidade educacional.
 
     Permite o envio quando:
@@ -344,50 +422,36 @@ def valida_dia_letivo_ou_inclusao_alimentacao_rpl(escola, data, modelo, periodos
           ``dia_letivo=True`` para a data; OU
         - a unidade possui DiaLetivoSIGPAE para a data; OU
         - existe uma Inclusão de Alimentação autorizada (não contínua) para a
-          mesma data com refeição e lanche, e os períodos escolares da
-          solicitação estão contidos nos períodos autorizados da inclusão.
+          mesma data que possua, período a período, Refeição e o tipo de lanche
+          solicitado (Lanche ou Lanche 4h).
 
     A verificação de ``DiaCalendario`` é aplicada somente de segunda a sexta.
     Aos sábados e domingos, valem sempre as regras de DiaLetivoSIGPAE ou de
     inclusão de alimentação autorizada.
 
-    Caso nenhuma das condições seja atendida, impede o envio da solicitação.
-
     Args:
         escola (Escola): Unidade educacional que está fazendo a solicitação.
         data (datetime.date): Data informada na solicitação.
         modelo (Model): Modelo de inclusão de alimentação a ser consultado.
-        periodos (Iterable[str], optional): Nomes dos períodos escolares da
-            solicitação RPL. Quando informado, valida se estão contidos nos
-            períodos autorizados da inclusão.
+        periodos_lanches (Iterable[dict], optional): Itens no formato
+            ``{"periodo": str, "lanches": list[str]}``, representando os
+            períodos da solicitação RPL e os tipos de lanche substituídos em
+            cada período.
 
     Returns:
         bool: ``True`` quando a data é válida para a solicitação RPL.
 
     Raises:
         serializers.ValidationError: Quando a data não é um dia letivo e não
-        existe uma inclusão de alimentação para a data, ou quando algum período
-        da solicitação não está autorizado na inclusão.
+        existe uma inclusão de alimentação para a data, quando algum período não
+        está autorizado na inclusão ou quando a inclusão não possui Refeição e o
+        lanche solicitado para o período.
     """
     if not eh_fim_de_semana(data) and escola_tem_dia_letivo_no_calendario(escola, data):
         return True
     if unidade_tem_dia_letivo_sigpae(escola, data):
         return True
-    if _inclusoes_alimentacao_autorizadas(escola, data, modelo).exists():
-        if periodos:
-            periodos_autorizados = _periodos_autorizados_inclusao(escola, data, modelo)
-            periodos_solicitados = {p for p in periodos if p}
-            if not periodos_solicitados.issubset(periodos_autorizados):
-                raise serializers.ValidationError(
-                    f'Para o dia {data.strftime("%d/%m")}, a inclusão está '
-                    "autorizada somente nos períodos "
-                    f"{_formata_periodos_para_mensagem(periodos_autorizados)}."
-                )
-        return True
-    raise serializers.ValidationError(
-        f'Dia {data.strftime("%d/%m")} não é um dia letivo ou não existe uma '
-        "inclusão de alimentação para a data"
-    )
+    return _valida_inclusao_alimentacao_rpl(escola, data, modelo, periodos_lanches)
 
 
 def deve_ser_dia_letivo_e_dia_da_semana(escola, data: datetime.date):

--- a/src/dados_comuns/validators.py
+++ b/src/dados_comuns/validators.py
@@ -17,12 +17,13 @@ from ..cardapio.alteracao_tipo_alimentacao_cei.models import (
 )
 from ..cardapio.alteracao_tipo_alimentacao_cemei.models import AlteracaoCardapioCEMEI
 from .constants import obter_dias_uteis_apos_hoje
-from .utils import datetime_range, eh_dia_util
+from .utils import datetime_range, eh_dia_util, eh_fim_de_semana
 
 calendario = BrazilSaoPauloCity()
 ERROR_MSG_EXISTE_RPL_MES = (
     "Já existe uma solicitação de RPL para o mês e período selecionado!"
 )
+RPL_MOTIVO_NOME = "RPL - Refeição por Lanche"
 
 
 def nao_pode_ser_no_passado(data: datetime.date):
@@ -149,6 +150,161 @@ def valida_duplicidade_solicitacoes_cemei(attrs):
     if solicitacoes:
         raise serializers.ValidationError(ERROR_MSG_EXISTE_RPL_MES)
     return True
+
+
+def escola_tem_dia_letivo_no_calendario(escola, data):
+    """Verifica se a escola possui dia letivo no DiaCalendario para a data.
+
+    A consulta considera qualquer registro de ``DiaCalendario`` da escola com
+    ``dia_letivo=True`` para a data informada.
+
+    Args:
+        escola (Escola): Unidade educacional que está fazendo a solicitação.
+        data (datetime.date): Data informada na solicitação.
+
+    Returns:
+        bool: ``True`` quando a escola possui ``DiaCalendario`` com
+        ``dia_letivo=True`` para a data.
+    """
+    return escola.calendario.filter(data=data, dia_letivo=True).exists()
+
+
+def unidade_tem_dia_letivo_sigpae(escola, data):
+    """Verifica se a unidade educacional possui DiaLetivoSIGPAE para a data.
+
+    A unidade é considerada contemplada pelo DiaLetivoSIGPAE quando:
+        - está listada diretamente no ``escolas`` do DiaLetivoSIGPAE da data; OU
+        - não existe nenhuma unidade listada no DiaLetivoSIGPAE da data, mas o
+          ``lotes`` e o ``tipos_unidade_escolar`` daquele dia contemplam o lote
+          e o tipo de unidade da escola.
+
+    Args:
+        escola (Escola): Unidade educacional que está fazendo a solicitação.
+        data (datetime.date): Data informada na solicitação.
+
+    Returns:
+        bool: ``True`` quando a escola está contemplada por algum
+        DiaLetivoSIGPAE da data.
+    """
+    from ..escola.dias_letivos.models import DiaLetivoSIGPAE
+
+    dias_letivos = DiaLetivoSIGPAE.objects.filter(data=data)
+    if dias_letivos.filter(escolas=escola).exists():
+        return True
+    return dias_letivos.filter(
+        escolas=None,
+        lotes=escola.lote,
+        tipos_unidade_escolar=escola.tipo_unidade,
+    ).exists()
+
+
+def existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(escola, data, modelo):
+    """Verifica se existe uma Inclusão de Alimentação autorizada na data.
+
+    Considera apenas inclusões que não sejam do tipo Inclusão Contínua e que
+    tenham, simultaneamente, os tipos de alimentação Refeição e Lanche.
+
+    Args:
+        escola (Escola): Unidade educacional que está fazendo a solicitação.
+        data (datetime.date): Data informada na solicitação.
+        modelo (Model): Modelo de inclusão de alimentação a ser consultado. Pode
+            ser ``GrupoInclusaoAlimentacaoNormal``,
+            ``InclusaoAlimentacaoDaCEI`` ou ``InclusaoDeAlimentacaoCEMEI``.
+
+    Returns:
+        bool: ``True`` quando existe inclusão autorizada com refeição e lanche
+        para a data informada.
+    """
+    from ..inclusao_alimentacao.models import (
+        GrupoInclusaoAlimentacaoNormal,
+        InclusaoAlimentacaoDaCEI,
+        InclusaoDeAlimentacaoCEMEI,
+    )
+
+    if modelo is GrupoInclusaoAlimentacaoNormal:
+        return (
+            modelo.objects.filter(
+                escola=escola,
+                status="CODAE_AUTORIZADO",
+                inclusoes_normais__data=data,
+                inclusoes_normais__cancelado=False,
+                quantidades_por_periodo__tipos_alimentacao__nome="Refeição",
+            )
+            .filter(quantidades_por_periodo__tipos_alimentacao__nome="Lanche")
+            .exists()
+        )
+
+    if modelo is InclusaoAlimentacaoDaCEI:
+        return (
+            modelo.objects.filter(
+                escola=escola,
+                status="CODAE_AUTORIZADO",
+                dias_motivos_da_inclusao_cei__data=data,
+                dias_motivos_da_inclusao_cei__cancelado=False,
+                tipos_alimentacao__nome="Refeição",
+            )
+            .filter(tipos_alimentacao__nome="Lanche")
+            .exists()
+        )
+
+    if modelo is InclusaoDeAlimentacaoCEMEI:
+        return (
+            modelo.objects.filter(
+                escola=escola,
+                status="CODAE_AUTORIZADO",
+                dias_motivos_da_inclusao_cemei__data=data,
+                dias_motivos_da_inclusao_cemei__cancelado=False,
+                quantidade_alunos_emei_da_inclusao_cemei__tipos_alimentacao__nome="Refeição",
+            )
+            .filter(
+                quantidade_alunos_emei_da_inclusao_cemei__tipos_alimentacao__nome="Lanche"
+            )
+            .exists()
+        )
+
+    return False
+
+
+def valida_dia_letivo_ou_inclusao_alimentacao_rpl(escola, data, modelo):
+    """Valida a data de uma solicitação RPL para a unidade educacional.
+
+    Permite o envio quando:
+        - de segunda a sexta, a escola possui ``DiaCalendario`` com
+          ``dia_letivo=True`` para a data; OU
+        - a unidade possui DiaLetivoSIGPAE para a data; OU
+        - existe uma Inclusão de Alimentação autorizada (não contínua) para a
+          mesma data com refeição e lanche.
+
+    A verificação de ``DiaCalendario`` é aplicada somente de segunda a sexta.
+    Aos sábados e domingos, valem sempre as regras de DiaLetivoSIGPAE ou de
+    inclusão de alimentação autorizada.
+
+    Caso nenhuma das condições seja atendida, impede o envio da solicitação.
+
+    Args:
+        escola (Escola): Unidade educacional que está fazendo a solicitação.
+        data (datetime.date): Data informada na solicitação.
+        modelo (Model): Modelo de inclusão de alimentação a ser consultado.
+
+    Returns:
+        bool: ``True`` quando a data é válida para a solicitação RPL.
+
+    Raises:
+        serializers.ValidationError: Quando a data não é um dia letivo e não
+        existe uma inclusão de alimentação para a data.
+    """
+    if not eh_fim_de_semana(data) and escola_tem_dia_letivo_no_calendario(escola, data):
+        return True
+    if unidade_tem_dia_letivo_sigpae(escola, data):
+        return True
+    if existe_inclusao_alimentacao_autorizada_com_refeicao_e_lanche(
+        escola, data, modelo
+    ):
+        return True
+    raise serializers.ValidationError(
+        f'Dia {data.strftime("%d/%m")} não é um dia letivo ou não existe uma '
+        "inclusão de alimentação para a data"
+    )
 
 
 def deve_ser_dia_letivo_e_dia_da_semana(escola, data: datetime.date):

--- a/src/dados_comuns/validators.py
+++ b/src/dados_comuns/validators.py
@@ -412,6 +412,32 @@ def _valida_inclusao_alimentacao_rpl(escola, data, modelo, periodos_lanches):
     return True
 
 
+def _valida_inclusao_alimentacao_cei_rpl(escola, data, modelo):
+    """Valida a solicitação RPL de CEI contra a inclusão de alimentação.
+
+    Para CEI, basta existir uma inclusão de alimentação autorizada para a data,
+    sem verificar os tipos de alimentação incluídos nem os períodos.
+
+    Args:
+        escola (Escola): Unidade educacional que está fazendo a solicitação.
+        data (datetime.date): Data informada na solicitação.
+        modelo (Model): Modelo de inclusão de alimentação a ser consultado.
+
+    Returns:
+        bool: ``True`` quando existe uma inclusão autorizada para a data.
+
+    Raises:
+        serializers.ValidationError: Quando não há inclusão autorizada para a
+        data.
+    """
+    if _inclusoes_alimentacao_autorizadas_base(escola, data, modelo).exists():
+        return True
+    raise serializers.ValidationError(
+        f'Dia {data.strftime("%d/%m")} não é um dia letivo ou não existe uma '
+        "inclusão de alimentação para a data"
+    )
+
+
 def valida_dia_letivo_ou_inclusao_alimentacao_rpl(
     escola, data, modelo, periodos_lanches=None
 ):
@@ -447,10 +473,14 @@ def valida_dia_letivo_ou_inclusao_alimentacao_rpl(
         está autorizado na inclusão ou quando a inclusão não possui Refeição e o
         lanche solicitado para o período.
     """
+    from ..inclusao_alimentacao.models import InclusaoAlimentacaoDaCEI
+
     if not eh_fim_de_semana(data) and escola_tem_dia_letivo_no_calendario(escola, data):
         return True
     if unidade_tem_dia_letivo_sigpae(escola, data):
         return True
+    if modelo is InclusaoAlimentacaoDaCEI:
+        return _valida_inclusao_alimentacao_cei_rpl(escola, data, modelo)
     return _valida_inclusao_alimentacao_rpl(escola, data, modelo, periodos_lanches)
 
 

--- a/src/dados_comuns/validators.py
+++ b/src/dados_comuns/validators.py
@@ -559,6 +559,7 @@ def valida_datas_alteracao_cardapio(attrs):
                     AlteracaoCardapio.workflow_class.CODAE_AUTORIZADO,
                 ],
                 alteracao_cardapio__escola=attrs["escola"],
+                alteracao_cardapio__motivo__nome="Lanche Emergencial",
                 alteracao_cardapio__substituicoes_periodo_escolar__periodo_escolar=substituicao[
                     "periodo_escolar"
                 ],

--- a/src/dieta_especial/utils/filtra_relatorio_recreio_nas_ferias.py
+++ b/src/dieta_especial/utils/filtra_relatorio_recreio_nas_ferias.py
@@ -16,7 +16,8 @@ def filtra_relatorio_recreio_nas_ferias(query_params: QueryDict) -> QuerySet:
     Args:
         query_params (QueryDict): Parâmetros de filtro da requisição.
     Returns:
-        QuerySet: Conjunto de solicitações filtradas e ordenadas por escola de destino.
+        QuerySet: Conjunto de solicitações filtradas e ordenadas por escola de
+        destino e, em caso de empate, pelo id.
     """
     filtros = gera_filtros_relatorio_recreio_nas_ferias(query_params)
     padrao = filtros.get("padrao", {})
@@ -49,7 +50,7 @@ def filtra_relatorio_recreio_nas_ferias(query_params: QueryDict) -> QuerySet:
 
     queryset = SolicitacaoDietaEspecial.objects.filter(
         filtro_matriculados | filtro_nao_matriculados
-    ).order_by("escola_destino__nome")
+    ).order_by("escola_destino__nome", "id")
 
     return queryset
 

--- a/src/escola/fixtures/factories/escola_factory.py
+++ b/src/escola/fixtures/factories/escola_factory.py
@@ -108,8 +108,8 @@ class LogAlunosMatriculadosPeriodoEscolaFactory(DjangoModelFactory):
 
 
 class FaixaEtariaFactory(DjangoModelFactory):
-    inicio = Sequence(lambda n: fake.unique.random_int(min=0, max=10))
-    fim = Sequence(lambda n: fake.unique.random_int(min=11, max=36))
+    inicio = Sequence(lambda n: fake.random_int(min=0, max=10))
+    fim = Sequence(lambda n: fake.random_int(min=11, max=36))
 
     class Meta:
         model = FaixaEtaria


### PR DESCRIPTION
# Neste PR:

Para as solicitações de **Alteração de Cardápio** com o motivo **RPL – Refeição por Lanche (SOMENTE)**, foram implementadas validações adicionais sobre a data informada, com o objetivo de evitar solicitações equivocadas pelas escolas.

A validação de **apenas uma RPL por mês** permanece como primeira checagem do fluxo. Somente quando não existir RPL já autorizada para o mês é que as novas regras são aplicadas.

### Regras de negócio implementadas

1. **Dia letivo (DiaCalendario) – segunda a sexta**

   Se a data informada cair de segunda a sexta e a escola possuir um `DiaCalendario` com `dia_letivo=True` para aquela data, a solicitação é permitida.

2. **DiaLetivoSIGPAE**

   Independentemente do dia da semana, se existir um `DiaLetivoSIGPAE` para a data que contemple a unidade educacional, a solicitação é permitida.

   A escola pode estar:
   - listada diretamente em `escolas`; ou
   - quando o dia não possuir nenhuma unidade listada, ser contemplada pelo **lote** e **tipo de unidade** da escola.

3. **Inclusão de Alimentação autorizada (não contínua)**

   Nos demais casos, incluindo sábados e domingos, a solicitação só é permitida quando existir uma **Inclusão de Alimentação** com status `CODAE_AUTORIZADO`, que não seja do tipo **Inclusão Contínua**, para a mesma data.

   As validações respeitam as particularidades de cada endpoint:

   - **Escolas em geral (`/alteracoes-cardapio/`)**  
     A inclusão deve contemplar cada período escolar da solicitação e possuir, em cada período, **Refeição** e o tipo de lanche solicitado (**Lanche** ou **Lanche 4h**).

   - **CEI (`/alteracoes-cardapio-cei/`)**  
     Basta existir uma inclusão autorizada para a data, sem necessidade de verificar tipos de alimentação ou períodos.

   - **CEMEI (`/alteracoes-cardapio-cemei/`)**  
     A parte solicitada (**CEI e/ou EMEI**) deve estar contemplada pela inclusão:
     - Para **CEI**, basta a existência da inclusão.
     - Para **EMEI**, aplica-se a mesma regra das escolas em geral: **Refeição + Lanche/Lanche 4h por período**.

### Mensagens de erro

- **Dia XX/XX não é um dia letivo ou não existe uma inclusão de alimentação para a data**  
  Quando não há dia letivo nem inclusão autorizada para a data.

- **Para o dia XX/XX, a inclusão está autorizada somente nos períodos X, Y e Z.**  
  Quando existe inclusão autorizada, mas algum período informado na solicitação não está contemplado.

- **Para o dia XX/XX, a inclusão autorizada não possui Refeição e Lanche autorizado para o período X.**  
  Quando a inclusão contempla o período, mas não possui Refeição e Lanche autorizados.

- **Para o dia XX/XX, a inclusão autorizada não possui Refeição e Lanche 4h autorizado para o período X.**  
  Quando a inclusão contempla o período, mas não possui Refeição e Lanche 4h autorizados.

- **Inclusão autorizada para o dia XX/XX somente para CEI / somente para EMEI**  
  No fluxo CEMEI, quando a parte solicitada (CEI ou EMEI) não está contemplada pela inclusão.

### Referência azure:
- [AB#154560](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/154560)