### PR TITLE
APi emails-terceirizadas-modulos metodo uuid

### DIFF
--- a/tests/cypress/e2e/api/validar_emails_terceirizadas_modulos.feature
+++ b/tests/cypress/e2e/api/validar_emails_terceirizadas_modulos.feature
@@ -8,6 +8,10 @@ Funcionalidade: Validar emails de terceirizadas por modulo
     Quando consulto os emails de terceirizadas por modulo
     Entao a consulta retorna status 200 e uma lista paginada valida
 
+  Cenario: Consultar email de terceirizada por UUID
+    Quando consulto um email de terceirizada por UUID existente
+    Entao a consulta por UUID retorna status 200 e os dados do email
+
   Cenario: Filtrar emails de terceirizadas por modulo com paginacao
     Quando consulto os emails de terceirizadas com limite 10 modulo "1" e deslocamento 10
     Entao a consulta filtrada retorna status 200 e respeita o limite informado

--- a/tests/cypress/support/commands_api/commands_emails_terceirizadas_modulos.js
+++ b/tests/cypress/support/commands_api/commands_emails_terceirizadas_modulos.js
@@ -30,3 +30,16 @@ Cypress.Commands.add('cadastrar_email_terceirizada_modulo', (dados) => {
 		failOnStatusCode: false,
 	})
 })
+
+Cypress.Commands.add('consultar_email_terceirizada_modulo_por_uuid', (uuid) => {
+	cy.request({
+		method: 'GET',
+		url:
+			Cypress.config('baseUrl') + `api/emails-terceirizadas-modulos/${uuid}/`,
+		timeout: 60000,
+		headers: {
+			Authorization: 'JWT ' + globalThis.token,
+		},
+		failOnStatusCode: false,
+	})
+})

--- a/tests/cypress/support/step_definitions/emails_terceirizadas_modulos.js
+++ b/tests/cypress/support/step_definitions/emails_terceirizadas_modulos.js
@@ -21,25 +21,28 @@ function dataHoraValida(valor) {
 	)
 }
 
+function validarRegistro(registro) {
+	expect(registro).to.include.all.keys(
+		'modulo',
+		'terceirizada',
+		'uuid',
+		'email',
+		'criado_em',
+	)
+	expect(registro.modulo).to.be.a('string')
+	expect(registro.terceirizada).to.be.a('string')
+	expect(registro.uuid).to.be.a('string').and.not.be.empty
+	expect(registro.email).to.be.a('string').and.not.be.empty
+	expect(registro.criado_em).to.be.a('string').and.not.be.empty
+	expect(dataHoraValida(registro.criado_em)).to.eq(true)
+}
+
 function validarListaPaginada(response) {
 	expect(response.body).to.include.all.keys('count', 'next', 'previous', 'results')
 	expect(response.body.count).to.be.a('number').and.at.least(0)
 	expect(response.body.results).to.be.an('array')
 
-	response.body.results.forEach((registro) => {
-		expect(registro).to.include.all.keys(
-			'modulo',
-			'terceirizada',
-			'uuid',
-			'email',
-			'criado_em',
-		)
-		expect(registro.modulo).to.be.a('string')
-		expect(registro.terceirizada).to.be.a('string')
-		expect(registro.uuid).to.be.a('string').and.not.be.empty
-		expect(registro.email).to.be.a('string').and.not.be.empty
-		expect(registro.criado_em).to.be.a('string').and.not.be.empty
-	})
+	response.body.results.forEach(validarRegistro)
 }
 
 Given(
@@ -52,6 +55,20 @@ Given(
 When('consulto os emails de terceirizadas por modulo', function () {
 	cy.consultar_emails_terceirizadas_modulos().then((response) => {
 		this.response = response
+	})
+})
+
+When('consulto um email de terceirizada por UUID existente', function () {
+	cy.consultar_emails_terceirizadas_modulos().then((consulta) => {
+		expect(consulta.status, JSON.stringify(consulta.body)).to.eq(200)
+		expect(consulta.body.results).to.be.an('array').and.not.be.empty
+
+		this.uuidConsultado = consulta.body.results[0].uuid
+		cy.consultar_email_terceirizada_modulo_por_uuid(this.uuidConsultado).then(
+			(response) => {
+				this.response = response
+			},
+		)
 	})
 })
 
@@ -116,6 +133,15 @@ Then(
 	function () {
 		expect(this.response.status, JSON.stringify(this.response.body)).to.eq(200)
 		validarListaPaginada(this.response)
+	},
+)
+
+Then(
+	'a consulta por UUID retorna status 200 e os dados do email',
+	function () {
+		expect(this.response.status, JSON.stringify(this.response.body)).to.eq(200)
+		validarRegistro(this.response.body)
+		expect(this.response.body.uuid).to.eq(this.uuidConsultado)
 	},
 )
 


### PR DESCRIPTION
Cenario: Consultar email de terceirizada por UUID
  Quando consulto um email de terceirizada por UUID existente
  Entao a consulta por UUID retorna status 200 e os dados do email

O cenário:
- Consulta primeiro a listagem.
- Obtém dinamicamente um UUID válido.
- Executa o GET de detalhe.
- Valida status 200.
- Confirma que o UUID retornado é o mesmo consultado.
- Valida modulo, terceirizada, uuid, email e criado_em.
- Aceita a data em formato ISO ou brasileiro.

[AB#155691](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/155691)
[AB#153721](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/153721)