### PR TITLE
feat(127149): :sparkles: ajusta serializer para retornar mais informações e permissões

### DIFF
--- a/src/pos_recebimento/__tests__/test_urls.py
+++ b/src/pos_recebimento/__tests__/test_urls.py
@@ -356,10 +356,33 @@ def test_termo_list_pagina_resultados(
     assert response.json()["next"] is not None
 
 
-def test_termo_list_negado_para_perfil_sem_permissao(
-    client_autenticado_qualidade,
+@pytest.mark.parametrize(
+    "nome_client",
+    [
+        "client_autenticado_dilog_cronograma",
+        "client_autenticado_qualidade",
+        "client_autenticado_dilog_diretoria",
+    ],
+)
+def test_termo_list_e_detalhe_liberados_para_perfis_de_visualizacao(
+    request,
+    nome_client,
     termo_listagem,
 ):
-    response = client_autenticado_qualidade.get("/pos-recebimento/termos/")
+    """Visualização é liberada para mais perfis do que o cadastro."""
+    client = request.getfixturevalue(nome_client)
+
+    assert client.get("/pos-recebimento/termos/").status_code == status.HTTP_200_OK
+    assert (
+        client.get(f"/pos-recebimento/termos/{termo_listagem.uuid}/").status_code
+        == status.HTTP_200_OK
+    )
+
+
+def test_termo_list_negado_para_perfil_fora_da_codae(
+    client_autenticado_distribuidor,
+    termo_listagem,
+):
+    response = client_autenticado_distribuidor.get("/pos-recebimento/termos/")
 
     assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/src/pos_recebimento/api/permissions.py
+++ b/src/pos_recebimento/api/permissions.py
@@ -3,19 +3,20 @@ from rest_framework.permissions import BasePermission
 from src.dados_comuns.constants import (
     COORDENADOR_CODAE_DILOG_LOGISTICA,
     DILOG_CRONOGRAMA,
+    DILOG_DIRETORIA,
+    DILOG_QUALIDADE,
 )
 from src.escola.models import Codae
 
 
-class PermissaoParaCadastrarTermoRecebimentoDefinitivo(BasePermission):
-    """Permissão para cadastrar/visualizar Termo de Recebimento Definitivo.
+class PermissaoTermoRecebimentoDefinitivo(BasePermission):
+    """Base das permissões do Termo de Recebimento Definitivo.
 
-    Apenas os perfis DILOG_CRONOGRAMA e COORDENADOR_CODAE_DILOG_LOGISTICA
-    (vinculados à CODAE) podem acessar as funcionalidades do módulo
-    Pós-Recebimento.
+    Exige usuário autenticado, com vínculo ativo na CODAE e perfil
+    presente em ``PERFIS_PERMITIDOS``, definido nas subclasses.
     """
 
-    PERFIS_PERMITIDOS = [DILOG_CRONOGRAMA, COORDENADOR_CODAE_DILOG_LOGISTICA]
+    PERFIS_PERMITIDOS = []
 
     def has_permission(self, request, view):
         usuario = request.user
@@ -25,3 +26,32 @@ class PermissaoParaCadastrarTermoRecebimentoDefinitivo(BasePermission):
             and isinstance(usuario.vinculo_atual.instituicao, Codae)
             and usuario.vinculo_atual.perfil.nome in self.PERFIS_PERMITIDOS
         )
+
+
+class PermissaoParaCadastrarTermoRecebimentoDefinitivo(
+    PermissaoTermoRecebimentoDefinitivo
+):
+    """Permissão para cadastrar Termo de Recebimento Definitivo.
+
+    Apenas os perfis DILOG_CRONOGRAMA e COORDENADOR_CODAE_DILOG_LOGISTICA
+    podem cadastrar termos.
+    """
+
+    PERFIS_PERMITIDOS = [DILOG_CRONOGRAMA, COORDENADOR_CODAE_DILOG_LOGISTICA]
+
+
+class PermissaoParaVisualizarTermoRecebimentoDefinitivo(
+    PermissaoTermoRecebimentoDefinitivo
+):
+    """Permissão para listar e detalhar Termo de Recebimento Definitivo.
+
+    Além dos perfis que cadastram, os perfis DILOG_QUALIDADE (fiscais do
+    termo) e DILOG_DIRETORIA podem visualizar os termos.
+    """
+
+    PERFIS_PERMITIDOS = [
+        DILOG_CRONOGRAMA,
+        COORDENADOR_CODAE_DILOG_LOGISTICA,
+        DILOG_QUALIDADE,
+        DILOG_DIRETORIA,
+    ]

--- a/src/pos_recebimento/api/serializers/serializers.py
+++ b/src/pos_recebimento/api/serializers/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from src.perfil.api.serializers import UsuarioSimplesSerializer
 from src.pre_recebimento.cronograma_entrega.api.serializers.serializers import (
-    CronogramaSimplesSerializer,
+    CronogramaSerializer,
 )
 from src.terceirizada.api.serializers.serializers import (
     ContratoSimplesSerializer,
@@ -15,7 +15,7 @@ from ...models import CronogramaTermoRecebimentoDefinitivo, TermoRecebimentoDefi
 class CronogramaTermoRecebimentoDefinitivoSerializer(serializers.ModelSerializer):
     """Cronograma do termo com valor de contrato e quantidade recebida."""
 
-    cronograma = CronogramaSimplesSerializer(read_only=True)
+    cronograma = CronogramaSerializer(read_only=True)
 
     class Meta:
         model = CronogramaTermoRecebimentoDefinitivo

--- a/src/pos_recebimento/api/viewsets.py
+++ b/src/pos_recebimento/api/viewsets.py
@@ -6,7 +6,10 @@ from src.dados_comuns.api.paginations import DefaultPagination
 
 from ..models import CronogramaTermoRecebimentoDefinitivo, TermoRecebimentoDefinitivo
 from .filters import TermoRecebimentoDefinitivoFilter
-from .permissions import PermissaoParaCadastrarTermoRecebimentoDefinitivo
+from .permissions import (
+    PermissaoParaCadastrarTermoRecebimentoDefinitivo,
+    PermissaoParaVisualizarTermoRecebimentoDefinitivo,
+)
 from .serializers.serializers import (
     TermoRecebimentoDefinitivoListagemSerializer,
     TermoRecebimentoDefinitivoSerializer,
@@ -51,6 +54,13 @@ class TermoRecebimentoDefinitivoViewSet(
             )
 
         return queryset
+
+    def get_permissions(self):
+        """Visualização é liberada para mais perfis do que o cadastro."""
+        if self.action in ("list", "retrieve"):
+            return [PermissaoParaVisualizarTermoRecebimentoDefinitivo()]
+
+        return [PermissaoParaCadastrarTermoRecebimentoDefinitivo()]
 
     def get_serializer_class(self):
         """Retorna o serializer adequado conforme a ação."""


### PR DESCRIPTION
# Este PR

 - Altera serializer de cronograma utilizado para o Termo de Recebimento;
 - Ajusta permissões para outros usuários com relação ao Termo de Recebimento;

### Referência Azure

 - [AB#127149](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/127149)
 - [AB#154407](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/154407)