### PR TITLE
Feature/154504 melhoria relatorio adesao tabela resultados pt2

### DIFF
--- a/src/medicao_inicial/__tests__/test_services/test_relatorio_adesao.py
+++ b/src/medicao_inicial/__tests__/test_services/test_relatorio_adesao.py
@@ -180,6 +180,43 @@ def test_obtem_resultados_relatorio_adesao_com_periodo_de_lancamento(
     }
 
 
+def test_obtem_resultados_relatorio_adesao_exclui_medicoes_de_recreio_nas_ferias(
+    categoria_medicao,
+    tipo_alimentacao_refeicao,
+    escola,
+    make_medicao,
+    make_valores_medicao,
+    make_periodo_escolar,
+    recreio_nas_ferias,
+):
+    mes = "12"
+    ano = "2025"
+    solicitacao_recreio = baker.make(
+        "SolicitacaoMedicaoInicial",
+        mes=mes,
+        ano=ano,
+        escola=escola,
+        rastro_lote=escola.lote,
+        status="MEDICAO_APROVADA_PELA_CODAE",
+        recreio_nas_ferias=recreio_nas_ferias,
+    )
+    periodo_escolar = make_periodo_escolar("MANHA")
+    _cria_medicao_com_valores(
+        solicitacao_recreio,
+        periodo_escolar,
+        categoria_medicao,
+        tipo_alimentacao_refeicao,
+        make_medicao,
+        make_valores_medicao,
+        range(1, 6),
+    )
+
+    query_params = QueryDict(f"mes_ano={mes}_{ano}")
+    resultados = obtem_resultados(query_params)
+
+    assert resultados == {}
+
+
 def test_obtem_resultados_relatorio_adesao_solicitacao_nao_aprovada_pela_codae(
     categoria_medicao,
     tipo_alimentacao_refeicao,

--- a/src/medicao_inicial/services/relatorio_adesao.py
+++ b/src/medicao_inicial/services/relatorio_adesao.py
@@ -33,7 +33,8 @@ def _obtem_medicoes(mes: str, ano: str, filtros: dict) -> QuerySet:
     """
     Obtém um QuerySet de medições filtradas por mês, ano e filtros adicionais.
     Recupera medições aprovadas pela CODAE para o período especificado, excluindo unidades
-    de educação infantil e aplicando filtros adicionais quando fornecidos.
+    de educação infantil e medições de recreio nas férias, além de aplicar filtros
+    adicionais quando fornecidos.
 
     Args:
         mes (str): mês de referência para a filtragem (formato: 'MM')
@@ -64,6 +65,7 @@ def _obtem_medicoes(mes: str, ano: str, filtros: dict) -> QuerySet:
                 TIPOS_UNIDADE_ESCOLAR.CEMEI.value,
             ]
         )
+        .exclude(solicitacao_medicao_inicial__recreio_nas_ferias__isnull=False)
     )
 
 


### PR DESCRIPTION
# Este PR:
- remove resultados do recreio nas férias do relatório de adesão

### Referência azure:
- [AB#154504](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/154504)