### PR TITLE
Hotfix/156433 correcao lancamento medicao inclusao

### DIFF
--- a/src/escola/__tests__/test_urls.py
+++ b/src/escola/__tests__/test_urls.py
@@ -429,6 +429,139 @@ def test_url_endpoint_periodos_escolares_inclusao_continua_por_mes_considera_enc
     }
 
 
+def test_url_endpoint_periodos_escolares_inclusao_continua_por_mes_nao_retorna_quando_encerrada_antes_do_mes(
+    client_autenticado_da_escola, escola
+):
+    client = client_autenticado_da_escola
+    motivo = baker.make("MotivoInclusaoContinua", nome="Programa Contínuo")
+    periodo_manha = baker.make("PeriodoEscolar", nome="MANHA")
+    inclusao = baker.make(
+        "InclusaoAlimentacaoContinua",
+        escola=escola,
+        rastro_escola=escola,
+        data_inicial=datetime.date(2026, 4, 1),
+        data_final=datetime.date(2026, 12, 31),
+        motivo=motivo,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_manha,
+        encerrado_a_partir_de=datetime.date(2026, 4, 30),
+    )
+
+    response = client.get(
+        "/periodos-escolares/inclusao-continua-por-mes/?mes=05&ano=2026"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["periodos"] is None
+
+
+def test_url_endpoint_periodos_escolares_inclusao_continua_por_mes_ignora_periodo_cancelado(
+    client_autenticado_da_escola, escola
+):
+    client = client_autenticado_da_escola
+    motivo = baker.make("MotivoInclusaoContinua", nome="Programa Contínuo")
+    periodo_manha = baker.make("PeriodoEscolar", nome="MANHA")
+    periodo_tarde = baker.make("PeriodoEscolar", nome="TARDE")
+    inclusao = baker.make(
+        "InclusaoAlimentacaoContinua",
+        escola=escola,
+        rastro_escola=escola,
+        data_inicial=datetime.date(2026, 5, 1),
+        data_final=datetime.date(2026, 5, 31),
+        motivo=motivo,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_manha,
+        cancelado=True,
+    )
+    baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_tarde,
+        cancelado=False,
+    )
+
+    response = client.get(
+        "/periodos-escolares/inclusao-continua-por-mes/?mes=05&ano=2026"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["periodos"] == {
+        "TARDE": str(periodo_tarde.uuid),
+    }
+
+
+def test_url_endpoint_periodos_escolares_inclusao_continua_por_mes_nao_retorna_sem_dia_da_semana_ativo(
+    client_autenticado_da_escola, escola
+):
+    client = client_autenticado_da_escola
+    motivo = baker.make("MotivoInclusaoContinua", nome="Programa Contínuo")
+    periodo_manha = baker.make("PeriodoEscolar", nome="MANHA")
+    inclusao = baker.make(
+        "InclusaoAlimentacaoContinua",
+        escola=escola,
+        rastro_escola=escola,
+        data_inicial=datetime.date(2026, 6, 1),
+        data_final=datetime.date(2026, 9, 30),
+        motivo=motivo,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_manha,
+        dias_semana=[4],
+        encerrado_a_partir_de=datetime.date(2026, 7, 2),
+    )
+
+    response = client.get(
+        "/periodos-escolares/inclusao-continua-por-mes/?mes=07&ano=2026"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["periodos"] is None
+
+
+def test_url_endpoint_periodos_escolares_inclusao_continua_por_mes_retorna_quando_dia_da_semana_ainda_cabe_no_encerramento(
+    client_autenticado_da_escola, escola
+):
+    client = client_autenticado_da_escola
+    motivo = baker.make("MotivoInclusaoContinua", nome="Programa Contínuo")
+    periodo_manha = baker.make("PeriodoEscolar", nome="MANHA")
+    inclusao = baker.make(
+        "InclusaoAlimentacaoContinua",
+        escola=escola,
+        rastro_escola=escola,
+        data_inicial=datetime.date(2026, 6, 1),
+        data_final=datetime.date(2026, 9, 30),
+        motivo=motivo,
+        status="CODAE_AUTORIZADO",
+    )
+    baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_manha,
+        dias_semana=[4],
+        encerrado_a_partir_de=datetime.date(2026, 7, 3),
+    )
+
+    response = client.get(
+        "/periodos-escolares/inclusao-continua-por-mes/?mes=07&ano=2026"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["periodos"] == {
+        "MANHA": str(periodo_manha.uuid),
+    }
+
+
 def test_url_endpoint_diretoria_regional_simplessima_actions(
     client_autenticado_da_dre, diretoria_regional
 ):

--- a/src/escola/api/viewsets.py
+++ b/src/escola/api/viewsets.py
@@ -74,6 +74,9 @@ from ...inclusao_alimentacao.models import (
     InclusaoDeAlimentacaoCEMEI,
     QuantidadePorPeriodo,
 )
+from ...inclusao_alimentacao.utils import (
+    quantidade_periodo_possui_dia_ativo_no_mes,
+)
 from ...paineis_consolidados.api.constants import FILTRO_DRE_UUID
 from ..forms import AlunosPorFaixaEtariaForm
 from ..models import (
@@ -355,29 +358,6 @@ class EscolaQuantidadeAlunosPorPeriodoEFaixaViewSet(GenericViewSet):
             return Response(
                 data={"detail": str(error)}, status=status.HTTP_400_BAD_REQUEST
             )
-
-
-def quantidade_periodo_possui_dia_ativo_no_mes(
-    quantidade_periodo, primeiro_dia_mes, ultimo_dia_mes
-):
-    inclusao = quantidade_periodo.inclusao_alimentacao_continua
-    data_inicio = max(inclusao.data_inicial, primeiro_dia_mes)
-    data_fim = min(inclusao.data_final, ultimo_dia_mes)
-    if quantidade_periodo.encerrado_a_partir_de:
-        data_fim = min(data_fim, quantidade_periodo.encerrado_a_partir_de)
-    if data_inicio > data_fim:
-        return False
-
-    dias_semana = quantidade_periodo.dias_semana
-    if not dias_semana:
-        return True
-
-    data = data_inicio
-    while data <= data_fim:
-        if data.weekday() in dias_semana:
-            return True
-        data += datetime.timedelta(days=1)
-    return False
 
 
 def periodos_inclusao_continua_ativas(instituicao, primeiro_dia_mes, ultimo_dia_mes):

--- a/src/escola/api/viewsets.py
+++ b/src/escola/api/viewsets.py
@@ -71,8 +71,8 @@ from ...escola.api.serializers_create import (
     MudancaFaixasEtariasCreateSerializer,
 )
 from ...inclusao_alimentacao.models import (
-    InclusaoAlimentacaoContinua,
     InclusaoDeAlimentacaoCEMEI,
+    QuantidadePorPeriodo,
 )
 from ...paineis_consolidados.api.constants import FILTRO_DRE_UUID
 from ..forms import AlunosPorFaixaEtariaForm
@@ -357,6 +357,73 @@ class EscolaQuantidadeAlunosPorPeriodoEFaixaViewSet(GenericViewSet):
             )
 
 
+def quantidade_periodo_possui_dia_ativo_no_mes(
+    quantidade_periodo, primeiro_dia_mes, ultimo_dia_mes
+):
+    inclusao = quantidade_periodo.inclusao_alimentacao_continua
+    data_inicio = max(inclusao.data_inicial, primeiro_dia_mes)
+    data_fim = min(inclusao.data_final, ultimo_dia_mes)
+    if quantidade_periodo.encerrado_a_partir_de:
+        data_fim = min(data_fim, quantidade_periodo.encerrado_a_partir_de)
+    if data_inicio > data_fim:
+        return False
+
+    dias_semana = quantidade_periodo.dias_semana
+    if not dias_semana:
+        return True
+
+    data = data_inicio
+    while data <= data_fim:
+        if data.weekday() in dias_semana:
+            return True
+        data += datetime.timedelta(days=1)
+    return False
+
+
+def periodos_inclusao_continua_ativas(instituicao, primeiro_dia_mes, ultimo_dia_mes):
+    quantidades_periodo = (
+        QuantidadePorPeriodo.objects.filter(
+            inclusao_alimentacao_continua__status="CODAE_AUTORIZADO",
+            inclusao_alimentacao_continua__rastro_escola=instituicao,
+            inclusao_alimentacao_continua__data_inicial__lte=ultimo_dia_mes,
+            cancelado=False,
+        )
+        .exclude(inclusao_alimentacao_continua__motivo__nome="ETEC")
+        .filter(
+            Q(
+                encerrado_a_partir_de__isnull=True,
+                inclusao_alimentacao_continua__data_final__gte=primeiro_dia_mes,
+            )
+            | Q(encerrado_a_partir_de__gte=primeiro_dia_mes)
+        )
+        .select_related("periodo_escolar", "inclusao_alimentacao_continua")
+    )
+    periodos = {}
+    for quantidade_periodo in quantidades_periodo:
+        if not quantidade_periodo_possui_dia_ativo_no_mes(
+            quantidade_periodo, primeiro_dia_mes, ultimo_dia_mes
+        ):
+            continue
+        periodo_escolar = quantidade_periodo.periodo_escolar
+        if periodo_escolar and periodo_escolar.nome:
+            periodos[periodo_escolar.nome] = periodo_escolar.uuid
+    return periodos
+
+
+def periodos_cemei_evento_especifico(instituicao, primeiro_dia_mes, ultimo_dia_mes):
+    cemei_periodos_emei = InclusaoDeAlimentacaoCEMEI.objects.filter(
+        status="CODAE_AUTORIZADO",
+        escola=instituicao,
+        dias_motivos_da_inclusao_cemei__motivo__nome="Evento Específico",
+        dias_motivos_da_inclusao_cemei__data__gte=primeiro_dia_mes,
+        dias_motivos_da_inclusao_cemei__data__lte=ultimo_dia_mes,
+    ).values_list(
+        "quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__nome",
+        "quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__uuid",
+    )
+    return {nome: uuid for nome, uuid in cemei_periodos_emei if nome is not None}
+
+
 class PeriodoEscolarViewSet(ReadOnlyModelViewSet):
     lookup_field = "uuid"
     queryset = PeriodoEscolar.objects.all()
@@ -436,6 +503,9 @@ class PeriodoEscolarViewSet(ReadOnlyModelViewSet):
         ``InclusaoDeAlimentacaoCEMEI`` com motivo ``Evento Especifico``,
         retornando os periodos escolares distintos (nome e uuid) com datas
         contidas no mes informado via query params ``mes`` e ``ano``.
+        Periodos encerrados antecipadamente (``encerrado_a_partir_de``),
+        cancelados ou sem dia da semana ativo no recorte do mes nao sao
+        retornados.
         """
         try:
             for param in ["mes", "ano"]:
@@ -443,55 +513,24 @@ class PeriodoEscolarViewSet(ReadOnlyModelViewSet):
                     raise ValidationError(f"{param} é obrigatório via query_params")
             mes = request.query_params.get("mes")
             ano = request.query_params.get("ano")
-            escola = request.query_params.get("escola")
             primeiro_dia_mes = datetime.date(int(ano), int(mes), 1)
             ultimo_dia_mes = get_ultimo_dia_mes(primeiro_dia_mes)
             instituicao = request.user.vinculo_atual.instituicao
+            escola = request.query_params.get("escola")
             if (
-                isinstance(instituicao, DiretoriaRegional)
-                or isinstance(instituicao, Codae)
-                or isinstance(instituicao, Terceirizada)
-            ) and escola:
+                isinstance(instituicao, (DiretoriaRegional, Codae, Terceirizada))
+                and escola
+            ):
                 instituicao = Escola.objects.get(uuid=escola)
-            periodos = dict(
-                InclusaoAlimentacaoContinua.objects.filter(
-                    status="CODAE_AUTORIZADO", rastro_escola=instituicao
-                )
-                .filter(
-                    data_inicial__lte=ultimo_dia_mes,
-                )
-                .filter(
-                    Q(
-                        quantidades_por_periodo__encerrado_a_partir_de__isnull=True,
-                        data_final__gte=primeiro_dia_mes,
-                    )
-                    | Q(
-                        quantidades_por_periodo__encerrado_a_partir_de__gte=primeiro_dia_mes
-                    )
-                )
-                .exclude(motivo__nome="ETEC")
-                .values_list(
-                    "quantidades_por_periodo__periodo_escolar__nome",
-                    "quantidades_por_periodo__periodo_escolar__uuid",
-                )
-                .distinct()
+            periodos = periodos_inclusao_continua_ativas(
+                instituicao, primeiro_dia_mes, ultimo_dia_mes
             )
-            cemei_base_qs = InclusaoDeAlimentacaoCEMEI.objects.filter(
-                status="CODAE_AUTORIZADO",
-                escola=instituicao,
-                dias_motivos_da_inclusao_cemei__motivo__nome="Evento Específico",
-                dias_motivos_da_inclusao_cemei__data__gte=primeiro_dia_mes,
-                dias_motivos_da_inclusao_cemei__data__lte=ultimo_dia_mes,
+            periodos.update(
+                periodos_cemei_evento_especifico(
+                    instituicao, primeiro_dia_mes, ultimo_dia_mes
+                )
             )
-            cemei_periodos_emei = cemei_base_qs.values_list(
-                "quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__nome",
-                "quantidade_alunos_emei_da_inclusao_cemei__periodo_escolar__uuid",
-            )
-            cemei_tuples = {
-                (nome, uuid) for nome, uuid in cemei_periodos_emei if nome is not None
-            }
-            periodos.update(dict(cemei_tuples))
-            return Response({"periodos": periodos if len(periodos) else None})
+            return Response({"periodos": periodos or None})
         except ValidationError as e:
             return Response({"detail": e}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/inclusao_alimentacao/__tests__/test_urls.py
+++ b/src/inclusao_alimentacao/__tests__/test_urls.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest.mock import patch
 
 import pytest
@@ -21,6 +22,7 @@ from ...dados_comuns.constants import (
     TERCEIRIZADA_RESPONDE_QUESTIONAMENTO,
     TERCEIRIZADA_TOMOU_CIENCIA,
 )
+from ...dados_comuns.constants import GRUPO_PROGRAMAS_E_PROJETOS
 from ...dados_comuns.fluxo_status import PedidoAPartirDaEscolaWorkflow
 from ...perfil.models import Usuario
 from ..models import (
@@ -886,6 +888,258 @@ def test_url_endpoint_inclusao_continua_escola_encerra_todos_periodos(
         ).count()
         == 1
     )
+
+
+def _cria_solicitacao_com_medicao_programas_e_projetos(
+    escola, mes, ano, dias=None
+):
+    from src.medicao_inicial.models import (
+        CategoriaMedicao,
+        GrupoMedicao,
+        Medicao,
+        SolicitacaoMedicaoInicial,
+        ValorMedicao,
+    )
+
+    grupo_programas, _ = GrupoMedicao.objects.get_or_create(
+        nome=GRUPO_PROGRAMAS_E_PROJETOS
+    )
+    categoria, _ = CategoriaMedicao.objects.get_or_create(nome="ALIMENTAÇÃO")
+    solicitacao = baker.make(
+        SolicitacaoMedicaoInicial,
+        escola=escola,
+        mes=mes,
+        ano=ano,
+    )
+    medicao_programas = baker.make(
+        Medicao,
+        solicitacao_medicao_inicial=solicitacao,
+        grupo=grupo_programas,
+    )
+    for dia in dias or ["01"]:
+        baker.make(
+            ValorMedicao,
+            medicao=medicao_programas,
+            categoria_medicao=categoria,
+            dia=dia,
+            nome_campo="numero_de_alunos",
+            valor="10",
+        )
+    medicao_manha = baker.make(
+        Medicao,
+        solicitacao_medicao_inicial=solicitacao,
+        periodo_escolar=baker.make("PeriodoEscolar", nome="MANHA"),
+    )
+    return solicitacao, medicao_programas, medicao_manha
+
+
+@freeze_time("2026-07-01")
+def test_escola_encerra_inclusao_continua_remove_medicao_programas_e_projetos_inativa(
+    client_autenticado_vinculo_escola_inclusao, escola
+):
+    motivo = baker.make("MotivoInclusaoContinua", nome="Programas/Projetos Contínuos")
+    periodo_manha = baker.make("PeriodoEscolar", nome="MANHA")
+    inclusao = baker.make(
+        "InclusaoAlimentacaoContinua",
+        escola=escola,
+        rastro_escola=escola,
+        rastro_lote=escola.lote,
+        rastro_dre=escola.diretoria_regional,
+        motivo=motivo,
+        data_inicial=datetime.date(2026, 4, 1),
+        data_final=datetime.date(2026, 9, 30),
+        status=PedidoAPartirDaEscolaWorkflow.CODAE_AUTORIZADO,
+    )
+    qtd = baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_manha,
+        dias_semana=[0, 1, 2, 3, 4, 5, 6],
+    )
+    solicitacao_abril, medicao_abril, medicao_manha_abril = (
+        _cria_solicitacao_com_medicao_programas_e_projetos(escola, "04", "2026")
+    )
+    solicitacao_junho, medicao_junho, medicao_manha_junho = (
+        _cria_solicitacao_com_medicao_programas_e_projetos(escola, "06", "2026")
+    )
+    solicitacao_julho, medicao_julho, medicao_manha_julho = (
+        _cria_solicitacao_com_medicao_programas_e_projetos(escola, "07", "2026")
+    )
+
+    response = client_autenticado_vinculo_escola_inclusao.patch(
+        f"/inclusoes-alimentacao-continua/{inclusao.uuid}/{ESCOLA_CANCELA}/",
+        content_type="application/json",
+        data={
+            "justificativa": "Projeto encerrado",
+            "encerrado_a_partir_de": "30/06/2026",
+            "quantidades_periodo": [{"uuid": str(qtd.uuid), "cancelado": True}],
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert solicitacao_abril.medicoes.filter(uuid=medicao_abril.uuid).exists()
+    assert solicitacao_abril.medicoes.filter(uuid=medicao_manha_abril.uuid).exists()
+    assert solicitacao_junho.medicoes.filter(uuid=medicao_junho.uuid).exists()
+    assert solicitacao_junho.medicoes.filter(uuid=medicao_manha_junho.uuid).exists()
+    assert solicitacao_julho.medicoes.filter(uuid=medicao_julho.uuid).exists()
+    assert solicitacao_julho.medicoes.filter(uuid=medicao_manha_julho.uuid).exists()
+
+
+@freeze_time("2026-07-01")
+def test_escola_encerra_inclusao_continua_remove_apenas_valores_a_partir_do_encerramento_no_mesmo_mes(
+    client_autenticado_vinculo_escola_inclusao, escola
+):
+    motivo = baker.make("MotivoInclusaoContinua", nome="Programas/Projetos Contínuos")
+    periodo_manha = baker.make("PeriodoEscolar", nome="MANHA")
+    inclusao = baker.make(
+        "InclusaoAlimentacaoContinua",
+        escola=escola,
+        rastro_escola=escola,
+        rastro_lote=escola.lote,
+        rastro_dre=escola.diretoria_regional,
+        motivo=motivo,
+        data_inicial=datetime.date(2026, 4, 1),
+        data_final=datetime.date(2026, 9, 30),
+        status=PedidoAPartirDaEscolaWorkflow.CODAE_AUTORIZADO,
+    )
+    qtd = baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_manha,
+        dias_semana=[0, 1, 2, 3, 4, 5, 6],
+    )
+    solicitacao_junho, medicao_junho, medicao_manha_junho = (
+        _cria_solicitacao_com_medicao_programas_e_projetos(
+            escola, "06", "2026", dias=["01", "15", "16", "30"]
+        )
+    )
+    solicitacao_julho, medicao_julho, medicao_manha_julho = (
+        _cria_solicitacao_com_medicao_programas_e_projetos(
+            escola, "07", "2026", dias=["01", "15"]
+        )
+    )
+
+    response = client_autenticado_vinculo_escola_inclusao.patch(
+        f"/inclusoes-alimentacao-continua/{inclusao.uuid}/{ESCOLA_CANCELA}/",
+        content_type="application/json",
+        data={
+            "justificativa": "Projeto encerrado",
+            "encerrado_a_partir_de": "15/06/2026",
+            "quantidades_periodo": [{"uuid": str(qtd.uuid), "cancelado": True}],
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert solicitacao_junho.medicoes.filter(uuid=medicao_junho.uuid).exists()
+    assert solicitacao_junho.medicoes.filter(uuid=medicao_manha_junho.uuid).exists()
+    assert set(medicao_junho.valores_medicao.values_list("dia", flat=True)) == {
+        "01",
+        "15",
+    }
+    assert solicitacao_julho.medicoes.filter(uuid=medicao_julho.uuid).exists()
+    assert solicitacao_julho.medicoes.filter(uuid=medicao_manha_julho.uuid).exists()
+    assert set(medicao_julho.valores_medicao.values_list("dia", flat=True)) == {
+        "01",
+        "15",
+    }
+
+
+@freeze_time("2026-07-01")
+def test_escola_cancela_inclusao_continua_sem_encerramento_nao_remove_medicao_programas_e_projetos(
+    client_autenticado_vinculo_escola_inclusao, escola
+):
+    motivo = baker.make("MotivoInclusaoContinua", nome="Programas/Projetos Contínuos")
+    periodo_manha = baker.make("PeriodoEscolar", nome="MANHA")
+    inclusao = baker.make(
+        "InclusaoAlimentacaoContinua",
+        escola=escola,
+        rastro_escola=escola,
+        rastro_lote=escola.lote,
+        rastro_dre=escola.diretoria_regional,
+        motivo=motivo,
+        data_inicial=datetime.date(2026, 7, 1),
+        data_final=datetime.date(2026, 7, 31),
+        status=PedidoAPartirDaEscolaWorkflow.CODAE_AUTORIZADO,
+    )
+    qtd_manha = baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_manha,
+        dias_semana=[0, 1, 2, 3, 4, 5, 6],
+    )
+    baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=baker.make("PeriodoEscolar", nome="TARDE"),
+        dias_semana=[0, 1, 2, 3, 4, 5, 6],
+    )
+    solicitacao, medicao_programas, medicao_manha = (
+        _cria_solicitacao_com_medicao_programas_e_projetos(escola, "07", "2026")
+    )
+
+    response = client_autenticado_vinculo_escola_inclusao.patch(
+        f"/inclusoes-alimentacao-continua/{inclusao.uuid}/{ESCOLA_CANCELA}/",
+        content_type="application/json",
+        data={
+            "justificativa": "cancelando parcialmente",
+            "quantidades_periodo": [{"uuid": str(qtd_manha.uuid), "cancelado": True}],
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert solicitacao.medicoes.filter(uuid=medicao_programas.uuid).exists()
+    assert solicitacao.medicoes.filter(uuid=medicao_manha.uuid).exists()
+
+
+@freeze_time("2026-07-01")
+def test_escola_encerra_inclusao_continua_mantem_medicao_quando_ainda_ha_periodo_ativo(
+    client_autenticado_vinculo_escola_inclusao, escola
+):
+    motivo = baker.make("MotivoInclusaoContinua", nome="Programas/Projetos Contínuos")
+    periodo_manha = baker.make("PeriodoEscolar", nome="MANHA")
+    periodo_tarde = baker.make("PeriodoEscolar", nome="TARDE")
+    inclusao = baker.make(
+        "InclusaoAlimentacaoContinua",
+        escola=escola,
+        rastro_escola=escola,
+        rastro_lote=escola.lote,
+        rastro_dre=escola.diretoria_regional,
+        motivo=motivo,
+        data_inicial=datetime.date(2026, 7, 1),
+        data_final=datetime.date(2026, 7, 31),
+        status=PedidoAPartirDaEscolaWorkflow.CODAE_AUTORIZADO,
+    )
+    qtd_manha = baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_manha,
+        dias_semana=[0, 1, 2, 3, 4, 5, 6],
+    )
+    baker.make(
+        "QuantidadePorPeriodo",
+        inclusao_alimentacao_continua=inclusao,
+        periodo_escolar=periodo_tarde,
+        dias_semana=[0, 1, 2, 3, 4, 5, 6],
+    )
+    solicitacao, medicao_programas, medicao_manha = (
+        _cria_solicitacao_com_medicao_programas_e_projetos(escola, "07", "2026")
+    )
+
+    response = client_autenticado_vinculo_escola_inclusao.patch(
+        f"/inclusoes-alimentacao-continua/{inclusao.uuid}/{ESCOLA_CANCELA}/",
+        content_type="application/json",
+        data={
+            "justificativa": "Encerrar só a manhã",
+            "encerrado_a_partir_de": "02/07/2026",
+            "quantidades_periodo": [
+                {"uuid": str(qtd_manha.uuid), "cancelado": True},
+            ],
+        },
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert solicitacao.medicoes.filter(uuid=medicao_programas.uuid).exists()
+    assert solicitacao.medicoes.filter(uuid=medicao_manha.uuid).exists()
 
 
 def test_url_endpoint_inclusao_continua_minhas_solicitacoes(

--- a/src/inclusao_alimentacao/api/viewsets.py
+++ b/src/inclusao_alimentacao/api/viewsets.py
@@ -27,6 +27,9 @@ from src.inclusao_alimentacao.models import (
     MotivoInclusaoContinua,
     MotivoInclusaoNormal,
 )
+from src.inclusao_alimentacao.utils import (
+    remove_medicao_programas_e_projetos_se_inclusao_inativa,
+)
 from src.relatorios.relatorios import (
     relatorio_inclusao_alimentacao_cei,
     relatorio_inclusao_alimentacao_cemei,
@@ -593,6 +596,9 @@ class InclusaoAlimentacaoContinuaViewSet(
                     justificativa=justificativa,
                 )
                 services.enviar_email_ue_cancelar_pedido_parcialmente(obj)
+                remove_medicao_programas_e_projetos_se_inclusao_inativa(
+                    obj, encerrado_a_partir_de
+                )
             else:
                 if len(uuids_selecionados) == obj.quantidades_periodo.count():
                     obj.cancelar_pedido(user=request.user, justificativa=justificativa)

--- a/src/inclusao_alimentacao/utils.py
+++ b/src/inclusao_alimentacao/utils.py
@@ -1,0 +1,178 @@
+"""Utilitários de inclusão contínua e medição de Programas e Projetos.
+
+Funções auxiliares para identificar períodos ativos no mês e remover
+valores de Programas e Projetos no mês em que a inclusão contínua é
+encerrada antecipadamente.
+"""
+
+import datetime
+
+from src.dados_comuns.constants import GRUPO_PROGRAMAS_E_PROJETOS
+from src.dados_comuns.utils import get_ultimo_dia_mes
+
+
+def quantidade_periodo_possui_dia_ativo_no_mes(
+    quantidade_periodo, primeiro_dia_mes, ultimo_dia_mes
+):
+    """Indica se a quantidade por período ainda tem dia vigente no mês.
+
+    A vigência considera o intervalo da inclusão contínua, o
+    ``encerrado_a_partir_de`` (a própria data continua ativa) e os dias da
+    semana da quantidade. Lista vazia de dias da semana equivale a todos os
+    dias.
+
+    Args:
+        quantidade_periodo (QuantidadePorPeriodo): Quantidade por período da
+            inclusão contínua.
+        primeiro_dia_mes (datetime.date): Primeiro dia do mês avaliado.
+        ultimo_dia_mes (datetime.date): Último dia do mês avaliado.
+
+    Returns:
+        bool: ``True`` se existir ao menos um dia ativo no mês.
+    """
+    inclusao = quantidade_periodo.inclusao_alimentacao_continua
+    data_inicio = max(inclusao.data_inicial, primeiro_dia_mes)
+    data_fim = min(inclusao.data_final, ultimo_dia_mes)
+    if quantidade_periodo.encerrado_a_partir_de:
+        data_fim = min(data_fim, quantidade_periodo.encerrado_a_partir_de)
+    if data_inicio > data_fim:
+        return False
+
+    dias_semana = quantidade_periodo.dias_semana
+    if not dias_semana:
+        return True
+
+    data = data_inicio
+    while data <= data_fim:
+        if data.weekday() in dias_semana:
+            return True
+        data += datetime.timedelta(days=1)
+    return False
+
+
+def inclusao_possui_quantidade_ativa_no_mes(
+    inclusao, primeiro_dia_mes, ultimo_dia_mes
+):
+    """Indica se a inclusão contínua ainda tem quantidade ativa no mês.
+
+    Quantidades canceladas são ignoradas.
+
+    Args:
+        inclusao (InclusaoAlimentacaoContinua): Inclusão contínua avaliada.
+        primeiro_dia_mes (datetime.date): Primeiro dia do mês avaliado.
+        ultimo_dia_mes (datetime.date): Último dia do mês avaliado.
+
+    Returns:
+        bool: ``True`` se alguma quantidade não cancelada ainda tiver dia
+        ativo no mês.
+    """
+    for quantidade_periodo in inclusao.quantidades_periodo.filter(cancelado=False):
+        if quantidade_periodo_possui_dia_ativo_no_mes(
+            quantidade_periodo, primeiro_dia_mes, ultimo_dia_mes
+        ):
+            return True
+    return False
+
+
+def medicao_programas_e_projetos_do_mes(escola, ano, mes):
+    """Busca a medição de Programas e Projetos da escola no mês/ano.
+
+    Há no máximo uma solicitação sem recreio nas férias por escola/mês/ano
+    e no máximo uma medição do grupo Programas e Projetos nessa solicitação.
+    Aceita mês com ou sem zero à esquerda.
+
+    Args:
+        escola (Escola): Escola da solicitação de medição inicial.
+        ano (int): Ano da solicitação.
+        mes (int): Mês da solicitação.
+
+    Returns:
+        Medicao: Medição do grupo Programas e Projetos, ou ``None`` se não
+        existir.
+    """
+    from src.medicao_inicial.models import Medicao
+
+    return Medicao.objects.filter(
+        solicitacao_medicao_inicial__escola=escola,
+        solicitacao_medicao_inicial__ano=str(ano),
+        solicitacao_medicao_inicial__mes__in={f"{mes:02d}", str(mes)},
+        solicitacao_medicao_inicial__recreio_nas_ferias__isnull=True,
+        grupo__nome=GRUPO_PROGRAMAS_E_PROJETOS,
+    ).first()
+
+
+def exclui_valores_medicao_a_partir_do_dia(medicao, dia):
+    """Exclui valores da medição de Programas e Projetos a partir de um dia.
+
+    A medição em si é mantida, assim como os valores anteriores ao dia
+    informado. A exclusão dos valores é feita em uma única consulta.
+
+    Args:
+        medicao (Medicao): Medição de Programas e Projetos. Se ``None``, a
+            função não faz nada.
+        dia (int): Primeiro dia cujos valores devem ser excluídos
+            (inclusivo).
+    """
+    if not medicao:
+        return
+    medicao.valores_medicao.filter(dia__gte=f"{dia:02d}").delete()
+
+
+def exclui_valores_inativos_mes_encerramento(medicao, inclusao, encerrado_a_partir_de):
+    """Remove valores inativos no mês do encerramento antecipado.
+
+    A data ``encerrado_a_partir_de`` permanece vigente. Só exclui valores
+    dos dias seguintes, e apenas se nenhuma quantidade da inclusão continuar
+    ativa nesse restante do mês. Se o encerramento cair no último dia do
+    mês, nada é removido.
+
+    Args:
+        medicao (Medicao): Medição de Programas e Projetos do mês do
+            encerramento. Se ``None``, a função não faz nada.
+        inclusao (InclusaoAlimentacaoContinua): Inclusão contínua encerrada.
+        encerrado_a_partir_de (datetime.date): Data a partir da qual a
+            inclusão foi encerrada.
+    """
+    if not medicao:
+        return
+    primeiro_dia_inativo = encerrado_a_partir_de + datetime.timedelta(days=1)
+    ultimo_dia_mes = get_ultimo_dia_mes(
+        datetime.date(encerrado_a_partir_de.year, encerrado_a_partir_de.month, 1)
+    )
+    if primeiro_dia_inativo > ultimo_dia_mes:
+        return
+    if inclusao_possui_quantidade_ativa_no_mes(
+        inclusao, primeiro_dia_inativo, ultimo_dia_mes
+    ):
+        return
+    exclui_valores_medicao_a_partir_do_dia(medicao, primeiro_dia_inativo.day)
+
+
+def remove_medicao_programas_e_projetos_se_inclusao_inativa(
+    inclusao, encerrado_a_partir_de
+):
+    """Remove valores inativos de Programas e Projetos no mês do encerramento.
+
+    Atua só no mês de ``encerrado_a_partir_de``: mantém a medição e os
+    valores ainda vigentes e exclui os posteriores à data. Meses anteriores
+    e posteriores não são alterados.
+
+    Não faz nada quando a escola ou a data de encerramento estão ausentes,
+    nem quando outra quantidade da inclusão permanece ativa no restante do
+    mês.
+
+    Args:
+        inclusao (InclusaoAlimentacaoContinua): Inclusão contínua encerrada.
+        encerrado_a_partir_de (datetime.date): Data a partir da qual a
+            inclusão foi encerrada.
+    """
+    escola = inclusao.escola
+    if not escola or not encerrado_a_partir_de:
+        return
+
+    medicao = medicao_programas_e_projetos_do_mes(
+        escola, encerrado_a_partir_de.year, encerrado_a_partir_de.month
+    )
+    exclui_valores_inativos_mes_encerramento(
+        medicao, inclusao, encerrado_a_partir_de
+    )

--- a/src/medicao_inicial/__tests__/test_serializer_create.py
+++ b/src/medicao_inicial/__tests__/test_serializer_create.py
@@ -1,11 +1,20 @@
+from datetime import date
+
 import pytest
 from model_bakery import baker
 
-from src.dados_comuns.constants import TIPOS_UNIDADE_ESCOLAR
+from src.dados_comuns.constants import GRUPO_PROGRAMAS_E_PROJETOS, TIPOS_UNIDADE_ESCOLAR
 from src.medicao_inicial.api.serializers_create import (
     DescontoFinanceiroUpdateSerializer,
+    SolicitacaoMedicaoInicialCreateSerializer,
 )
-from src.medicao_inicial.models import DescontoFinanceiro
+from src.medicao_inicial.models import (
+    CategoriaMedicao,
+    DescontoFinanceiro,
+    GrupoMedicao,
+    Medicao,
+    ValorMedicao,
+)
 
 
 @pytest.mark.django_db
@@ -293,3 +302,368 @@ def test_desconto_financeiro_serializer_grupo_emebs(
 
     assert instance_updated.infantil_ou_fundamental == "FUNDAMENTAL"
     assert instance_updated.tipo_alimentacao == tipo_alimentacao_refeicao
+
+
+DIAS_SEMANA_TODOS = [0, 1, 2, 3, 4, 5, 6]
+MOTIVO_PROGRAMAS_PROJETOS = "Programas/Projetos Contínuos"
+
+
+@pytest.mark.django_db
+class TestCriaValoresMedicaoInclusoesContinuas:
+    def _setup_dependencias(self):
+        categoria, _ = CategoriaMedicao.objects.get_or_create(nome="ALIMENTAÇÃO")
+        grupo_programas, _ = GrupoMedicao.objects.get_or_create(
+            nome=GRUPO_PROGRAMAS_E_PROJETOS
+        )
+        grupo_etec, _ = GrupoMedicao.objects.get_or_create(nome="ETEC")
+        return categoria, grupo_programas, grupo_etec
+
+    def _setup_escola(self):
+        return baker.make("Escola")
+
+    def _setup_solicitacao(self, escola, mes="09", ano="2023"):
+        return baker.make(
+            "SolicitacaoMedicaoInicial",
+            escola=escola,
+            mes=mes,
+            ano=ano,
+        )
+
+    def _setup_inclusao_continua(
+        self,
+        escola,
+        motivo_nome=MOTIVO_PROGRAMAS_PROJETOS,
+        data_inicial=date(2023, 9, 1),
+        data_final=date(2023, 9, 30),
+        status="CODAE_AUTORIZADO",
+        numero_alunos=10,
+        encerrado_a_partir_de=None,
+        cancelado=False,
+        dias_semana=None,
+        periodo_escolar=None,
+    ):
+        motivo = baker.make("MotivoInclusaoContinua", nome=motivo_nome)
+        inclusao = baker.make(
+            "InclusaoAlimentacaoContinua",
+            escola=escola,
+            rastro_escola=escola,
+            data_inicial=data_inicial,
+            data_final=data_final,
+            motivo=motivo,
+            status=status,
+        )
+        if periodo_escolar is None:
+            periodo_escolar = baker.make("PeriodoEscolar", nome="MANHA")
+        baker.make(
+            "QuantidadePorPeriodo",
+            inclusao_alimentacao_continua=inclusao,
+            periodo_escolar=periodo_escolar,
+            numero_alunos=numero_alunos,
+            dias_semana=dias_semana or DIAS_SEMANA_TODOS,
+            encerrado_a_partir_de=encerrado_a_partir_de,
+            cancelado=cancelado,
+        )
+        return inclusao
+
+    def _valores_numero_alunos(self, solicitacao, grupo_nome):
+        medicao = solicitacao.medicoes.filter(grupo__nome=grupo_nome).first()
+        if not medicao:
+            return ValorMedicao.objects.none()
+        return medicao.valores_medicao.filter(
+            nome_campo="numero_de_alunos",
+            categoria_medicao__nome="ALIMENTAÇÃO",
+        )
+
+    def _dias_criados(self, valores):
+        return set(valores.values_list("dia", flat=True))
+
+    def test_cria_valores_quando_inclusao_programas_projetos_autorizada_e_ativa(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+        self._setup_inclusao_continua(escola, numero_alunos=15)
+
+        SolicitacaoMedicaoInicialCreateSerializer().cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
+            solicitacao
+        )
+
+        valores = self._valores_numero_alunos(solicitacao, GRUPO_PROGRAMAS_E_PROJETOS)
+        assert valores.count() == 30
+        assert self._dias_criados(valores) == {f"{dia:02d}" for dia in range(1, 31)}
+        assert all(valor.valor == "15" for valor in valores)
+
+    def test_nao_cria_valores_nem_medicao_quando_encerramento_antes_do_mes(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola, mes="09", ano="2023")
+        self._setup_inclusao_continua(
+            escola,
+            data_inicial=date(2023, 8, 1),
+            data_final=date(2023, 9, 30),
+            encerrado_a_partir_de=date(2023, 8, 20),
+        )
+
+        SolicitacaoMedicaoInicialCreateSerializer().cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
+            solicitacao
+        )
+
+        assert not Medicao.objects.filter(
+            solicitacao_medicao_inicial=solicitacao,
+            grupo__nome=GRUPO_PROGRAMAS_E_PROJETOS,
+        ).exists()
+        assert not self._valores_numero_alunos(
+            solicitacao, GRUPO_PROGRAMAS_E_PROJETOS
+        ).exists()
+
+    def test_nao_cria_quando_encerramento_no_ultimo_dia_do_mes_anterior(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola, mes="09", ano="2023")
+        self._setup_inclusao_continua(
+            escola,
+            data_inicial=date(2023, 8, 1),
+            data_final=date(2023, 12, 31),
+            encerrado_a_partir_de=date(2023, 8, 31),
+        )
+
+        SolicitacaoMedicaoInicialCreateSerializer().cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
+            solicitacao
+        )
+
+        assert not Medicao.objects.filter(
+            solicitacao_medicao_inicial=solicitacao,
+            grupo__nome=GRUPO_PROGRAMAS_E_PROJETOS,
+        ).exists()
+
+    def test_cria_valores_somente_ate_data_encerramento_antecipado_no_mesmo_mes(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+        self._setup_inclusao_continua(
+            escola,
+            numero_alunos=12,
+            encerrado_a_partir_de=date(2023, 9, 10),
+        )
+
+        SolicitacaoMedicaoInicialCreateSerializer().cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
+            solicitacao
+        )
+
+        valores = self._valores_numero_alunos(solicitacao, GRUPO_PROGRAMAS_E_PROJETOS)
+        assert self._dias_criados(valores) == {f"{dia:02d}" for dia in range(1, 11)}
+        assert valores.count() == 10
+        assert all(valor.valor == "12" for valor in valores)
+
+    def test_cria_apenas_primeiro_dia_quando_encerramento_no_primeiro_dia_do_mes(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+        self._setup_inclusao_continua(
+            escola,
+            encerrado_a_partir_de=date(2023, 9, 1),
+        )
+
+        SolicitacaoMedicaoInicialCreateSerializer().cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
+            solicitacao
+        )
+
+        valores = self._valores_numero_alunos(solicitacao, GRUPO_PROGRAMAS_E_PROJETOS)
+        assert self._dias_criados(valores) == {"01"}
+
+    def test_nao_cria_quando_inclusao_nao_autorizada(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+        self._setup_inclusao_continua(escola, status="ESCOLA_CANCELOU")
+
+        SolicitacaoMedicaoInicialCreateSerializer().cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
+            solicitacao
+        )
+
+        assert not Medicao.objects.filter(
+            solicitacao_medicao_inicial=solicitacao,
+            grupo__nome=GRUPO_PROGRAMAS_E_PROJETOS,
+        ).exists()
+
+    def test_nao_cria_quando_nao_existe_inclusao_continua(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+
+        SolicitacaoMedicaoInicialCreateSerializer().cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
+            solicitacao
+        )
+
+        assert not solicitacao.medicoes.exists()
+
+    def test_etec_respeita_encerramento_antecipado_no_mesmo_mes(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+        self._setup_inclusao_continua(
+            escola,
+            motivo_nome="ETEC",
+            numero_alunos=8,
+            encerrado_a_partir_de=date(2023, 9, 15),
+        )
+
+        SolicitacaoMedicaoInicialCreateSerializer().cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
+            solicitacao
+        )
+
+        valores = self._valores_numero_alunos(solicitacao, "ETEC")
+        assert self._dias_criados(valores) == {f"{dia:02d}" for dia in range(1, 16)}
+        assert not Medicao.objects.filter(
+            solicitacao_medicao_inicial=solicitacao,
+            grupo__nome=GRUPO_PROGRAMAS_E_PROJETOS,
+        ).exists()
+
+    def test_etec_nao_cria_medicao_quando_encerrada_antes_do_mes(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+        self._setup_inclusao_continua(
+            escola,
+            motivo_nome="ETEC",
+            data_inicial=date(2023, 8, 1),
+            data_final=date(2023, 9, 30),
+            encerrado_a_partir_de=date(2023, 8, 10),
+        )
+
+        SolicitacaoMedicaoInicialCreateSerializer().cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
+            solicitacao
+        )
+
+        assert not Medicao.objects.filter(
+            solicitacao_medicao_inicial=solicitacao,
+            grupo__nome="ETEC",
+        ).exists()
+
+    def test_soma_apenas_periodos_ainda_ativos_apos_encerramento_parcial(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+        periodo_manha = baker.make("PeriodoEscolar", nome="MANHA")
+        periodo_tarde = baker.make("PeriodoEscolar", nome="TARDE")
+        inclusao = self._setup_inclusao_continua(
+            escola,
+            numero_alunos=10,
+            encerrado_a_partir_de=date(2023, 9, 10),
+            periodo_escolar=periodo_manha,
+        )
+        baker.make(
+            "QuantidadePorPeriodo",
+            inclusao_alimentacao_continua=inclusao,
+            periodo_escolar=periodo_tarde,
+            numero_alunos=20,
+            dias_semana=DIAS_SEMANA_TODOS,
+            encerrado_a_partir_de=None,
+            cancelado=False,
+        )
+
+        SolicitacaoMedicaoInicialCreateSerializer().cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
+            solicitacao
+        )
+
+        valores = self._valores_numero_alunos(solicitacao, GRUPO_PROGRAMAS_E_PROJETOS)
+        valores_por_dia = {valor.dia: valor.valor for valor in valores}
+        assert valores_por_dia["10"] == "30"
+        assert valores_por_dia["11"] == "20"
+        assert valores_por_dia["30"] == "20"
+        assert "01" in valores_por_dia
+
+    def test_nao_recria_valor_quando_numero_de_alunos_ja_existe_no_dia(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+        self._setup_inclusao_continua(escola, numero_alunos=10)
+        categoria = CategoriaMedicao.objects.get(nome="ALIMENTAÇÃO")
+        grupo = GrupoMedicao.objects.get(nome=GRUPO_PROGRAMAS_E_PROJETOS)
+        medicao = baker.make(
+            "Medicao",
+            solicitacao_medicao_inicial=solicitacao,
+            grupo=grupo,
+        )
+        baker.make(
+            "ValorMedicao",
+            medicao=medicao,
+            categoria_medicao=categoria,
+            dia="05",
+            nome_campo="numero_de_alunos",
+            valor="99",
+        )
+
+        SolicitacaoMedicaoInicialCreateSerializer().cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
+            solicitacao
+        )
+
+        valor_dia_05 = medicao.valores_medicao.get(
+            dia="05",
+            nome_campo="numero_de_alunos",
+            categoria_medicao=categoria,
+        )
+        assert valor_dia_05.valor == "99"
+        assert medicao.valores_medicao.filter(
+            dia="05",
+            nome_campo="numero_de_alunos",
+        ).count() == 1
+
+    def test_nao_cria_medicao_quando_todos_os_dias_ficam_sem_alunos(self):
+        self._setup_dependencias()
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+        inclusao = self._setup_inclusao_continua(
+            escola,
+            encerrado_a_partir_de=date(2023, 8, 31),
+            data_inicial=date(2023, 8, 1),
+            data_final=date(2023, 9, 30),
+        )
+        serializer = SolicitacaoMedicaoInicialCreateSerializer()
+        serializer.cria_valores_medicao_logs_numero_alunos_inclusoes_continuas(
+            solicitacao,
+            escola.inclusoes_alimentacao_continua.all(),
+            30,
+            "Programas/Projetos",
+            GRUPO_PROGRAMAS_E_PROJETOS,
+        )
+
+        assert inclusao.quantidades_periodo.exists()
+        assert not Medicao.objects.filter(
+            solicitacao_medicao_inicial=solicitacao,
+            grupo__nome=GRUPO_PROGRAMAS_E_PROJETOS,
+        ).exists()
+
+    def test_valores_por_dia_respeitam_data_inicial_data_final_e_encerramento(self):
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+        inclusao = self._setup_inclusao_continua(
+            escola,
+            data_inicial=date(2023, 9, 5),
+            data_final=date(2023, 9, 20),
+            numero_alunos=7,
+            encerrado_a_partir_de=date(2023, 9, 12),
+        )
+        serializer = SolicitacaoMedicaoInicialCreateSerializer()
+
+        valores_por_dia = serializer._valores_numero_alunos_inclusoes_continuas_por_dia(
+            solicitacao,
+            escola.inclusoes_alimentacao_continua.filter(uuid=inclusao.uuid),
+            30,
+        )
+
+        assert set(valores_por_dia.keys()) == set(range(5, 13))
+        assert all(numero == 7 for numero in valores_por_dia.values())
+
+    def test_quantidade_periodo_cancelada_nao_entra_no_numero_de_alunos(self):
+        escola = self._setup_escola()
+        solicitacao = self._setup_solicitacao(escola)
+        self._setup_inclusao_continua(escola, numero_alunos=10, cancelado=True)
+        serializer = SolicitacaoMedicaoInicialCreateSerializer()
+
+        valores_por_dia = serializer._valores_numero_alunos_inclusoes_continuas_por_dia(
+            solicitacao,
+            escola.inclusoes_alimentacao_continua.all(),
+            30,
+        )
+
+        assert valores_por_dia == {}

--- a/src/medicao_inicial/api/serializers_create.py
+++ b/src/medicao_inicial/api/serializers_create.py
@@ -121,6 +121,8 @@ from ..validators import (
     validate_solicitacoes_programas_e_projetos_emebs,
     validate_solicitacoes_programas_e_projetos_escola_sem_alunos_regulares,
     validate_ultimo_dia_mes_letivo,
+    get_filtro_inclusao_continua_ativa,
+    get_filtro_quantidade_periodo_ativa,
 )
 
 
@@ -825,7 +827,9 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
         dia_semana = data.weekday()
         numero_alunos = 0
         for quantidade_periodo in inclusao.quantidades_periodo.filter(
-            dias_semana__icontains=dia_semana, cancelado=False
+            get_filtro_quantidade_periodo_ativa(data),
+            dias_semana__icontains=dia_semana,
+            cancelado=False,
         ):
             numero_alunos += quantidade_periodo.numero_alunos
         return numero_alunos
@@ -858,26 +862,26 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
         nome_motivo: str,
         nome_grupo: str,
     ) -> None:
-        if not inclusoes_continuas.filter(motivo__nome__icontains=nome_motivo).exists():
+        inclusoes_do_motivo = inclusoes_continuas.filter(
+            motivo__nome__icontains=nome_motivo
+        )
+        if not inclusoes_do_motivo.exists():
+            return
+        valores_por_dia = self._valores_numero_alunos_inclusoes_continuas_por_dia(
+            instance, inclusoes_do_motivo, quantidade_dias_mes
+        )
+        if not valores_por_dia:
             return
         categoria = CategoriaMedicao.objects.get(nome="ALIMENTAÇÃO")
         medicao = self.retorna_medicao_por_nome_grupo(instance, nome_grupo)
         valores_medicao_a_criar = []
-        for dia in range(1, quantidade_dias_mes + 1):
-            data = date(year=int(instance.ano), month=int(instance.mes), day=dia)
-            numero_alunos = 0
-            for inclusao in inclusoes_continuas.filter(
-                motivo__nome__icontains=nome_motivo
-            ):
-                if not (inclusao.data_inicial <= data <= inclusao.data_final):
-                    continue
-                if medicao.valores_medicao.filter(
-                    categoria_medicao=categoria,
-                    dia=f"{dia:02d}",
-                    nome_campo="numero_de_alunos",
-                ).exists():
-                    continue
-                numero_alunos += self.retorna_numero_alunos_dia(inclusao, data)
+        for dia, numero_alunos in valores_por_dia.items():
+            if medicao.valores_medicao.filter(
+                categoria_medicao=categoria,
+                dia=f"{dia:02d}",
+                nome_campo="numero_de_alunos",
+            ).exists():
+                continue
             valores_medicao_a_criar = self.cria_valor_medicao(
                 numero_alunos,
                 medicao,
@@ -887,6 +891,24 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
                 valores_medicao_a_criar,
             )
         ValorMedicao.objects.bulk_create(valores_medicao_a_criar)
+
+    def _valores_numero_alunos_inclusoes_continuas_por_dia(
+        self,
+        instance: SolicitacaoMedicaoInicial,
+        inclusoes_do_motivo: QuerySet,
+        quantidade_dias_mes: int,
+    ) -> dict:
+        valores_por_dia = {}
+        for dia in range(1, quantidade_dias_mes + 1):
+            data = date(year=int(instance.ano), month=int(instance.mes), day=dia)
+            numero_alunos = 0
+            for inclusao in inclusoes_do_motivo:
+                if not (inclusao.data_inicial <= data <= inclusao.data_final):
+                    continue
+                numero_alunos += self.retorna_numero_alunos_dia(inclusao, data)
+            if numero_alunos > 0:
+                valores_por_dia[dia] = numero_alunos
+        return valores_por_dia
 
     def cria_valores_medicao_logs_numero_alunos_inclusoes_continuas_emef_emei(
         self, instance: SolicitacaoMedicaoInicial
@@ -899,10 +921,13 @@ class SolicitacaoMedicaoInicialCreateSerializer(serializers.ModelSerializer):
             year=int(instance.ano), month=int(instance.mes), day=quantidade_dias_mes
         )
         primeiro_dia_mes = date(year=int(instance.ano), month=int(instance.mes), day=1)
-        inclusoes_continuas = escola.inclusoes_alimentacao_continua.filter(
-            status="CODAE_AUTORIZADO",
-            data_inicial__lte=ultimo_dia_mes,
-            data_final__gte=primeiro_dia_mes,
+        inclusoes_continuas = (
+            escola.inclusoes_alimentacao_continua.filter(
+                status="CODAE_AUTORIZADO",
+                data_inicial__lte=ultimo_dia_mes,
+            )
+            .filter(get_filtro_inclusao_continua_ativa(primeiro_dia_mes))
+            .distinct()
         )
         if not inclusoes_continuas.count():
             return


### PR DESCRIPTION
**Este pull request**
Ajusta fluxo de processamento e retorno de informações com base no encerramento da inclusão contínua:
- Ajuste métodos de processamento ao criar valores de medição na finalização de lançamento.
- Não retornar períodos em que o dia não é contemplado devido ao cancelamento.
- Ao cancelar uma inclusão verificar se existe medição criada e remover os dados "descontinuados".

Referência no Azure: [AB#156433](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/156433)