### PR TITLE
Hotfix/atualiza-imagem-python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3-bullseye AS docs-builder
+FROM python:3.13.3-bookworm AS docs-builder
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -13,7 +13,7 @@ COPY . /code/
 RUN pipenv install --system --deploy --ignore-pipfile --dev && \
     sphinx-build -b html docs/source docs/build/html
 
-FROM python:3.13.3-bullseye
+FROM python:3.13.3-bookworm
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
# Este PR:
- atualiza imagem do python para bookworm após falha na esteira

<img width="1856" height="509" alt="Screenshot from 2026-09-08 10-52-31" src="https://github.com/user-attachments/assets/1b236649-8c82-4b67-8e72-8971b6fdfe98" />
